### PR TITLE
Setup tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,72 @@
+// Karma configuration
+// Generated on Fri Dec 04 2015 17:29:55 GMT-0800 (PST)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'fixture', 'chai'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'bliss.js',
+      'tests/**/*.js',
+      'tests/fixtures/**/*.html'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      '**/*.html'   : ['html2js']
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['PhantomJS', 'Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultanous
+    concurrency: Infinity
+  })
+}

--- a/package.json
+++ b/package.json
@@ -25,21 +25,21 @@
   },
   "homepage": "https://github.com/LeaVerou/bliss",
   "devDependencies": {
+    "chai": "^3.4.1",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.7",
     "karma": "^0.13.15",
+    "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.2.2",
     "karma-fixture": "^0.2.5",
     "karma-html2js-preprocessor": "^0.1.0",
     "karma-jasmine": "^0.3.6",
     "karma-mocha": "^0.2.1",
     "karma-phantomjs-launcher": "^0.2.1",
-    "karma-requirejs": "^0.2.2",
-    "phantomjs": "^1.9.19",
-    "requirejs": "^2.1.22"
+    "phantomjs": "^1.9.19"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,17 @@
     "gulp-concat": "^2.6.0",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.1",
-    "gulp-util": "^3.0.7"
-  }
+    "gulp-util": "^3.0.7",
+    "karma": "^0.13.15",
+    "karma-chrome-launcher": "^0.2.2",
+    "karma-fixture": "^0.2.5",
+    "karma-html2js-preprocessor": "^0.1.0",
+    "karma-jasmine": "^0.3.6",
+    "karma-mocha": "^0.2.1",
+    "karma-phantomjs-launcher": "^0.2.1",
+    "karma-requirejs": "^0.2.2",
+    "phantomjs": "^1.9.19",
+    "requirejs": "^2.1.22"
+  },
+  "dependencies": {}
 }

--- a/tests/CoreSpec.js
+++ b/tests/CoreSpec.js
@@ -1,0 +1,17 @@
+
+describe("Core Bliss", function () {
+  "use strict";
+
+  beforeEach(function () {
+    fixture.setBase('tests/fixtures')
+    this.fixture = fixture.load('core.html');
+    document.body.innerHTML += this.fixture[0]
+  });
+
+  // testing setup
+  it("has the fixture on the dom", function () {
+    expect($('#fixture-container')).to.not.be.null;
+  });
+
+});
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,8 @@
+# Running the tests
+
+cd to the root of the project
+```
+karma start
+```
+
+thats it, Karma will monitor your tests directory for any files with *Spec.js, and run them on change.

--- a/tests/fixtures/core.html
+++ b/tests/fixtures/core.html
@@ -1,0 +1,4 @@
+
+<div id="fixture-container">
+  <div class="foo"></div>
+</div>


### PR DESCRIPTION
Inital setup of testing framework

*Using:*
- Karma
- Mocha, with Chai
- html files for fixtures
- Phantomjs
- Chrome

Many more browsers can be added to Karma, even IE and such. This should be useful for Bliss.
The first test I put in asserts that fixtures can be loaded onto the DOM.

to run the tests, from the root of the project
```
npm install
karma start
```