### PR TITLE
Change tag to tagName

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -217,7 +217,7 @@ $$(element.attributes).filter(function(attribute){
 			<dd>The tag name of the element to create.</dd>
 
 			<dt class="object">options</dt>
-			<dd>An object with several options for the new element (properties, attributes, events etc). For details about what options this object accepts, see <code>$.set()</code>. If <code>tagName</code> is omitted, you need to provide it in the <code>options</code> object.</dd>
+			<dd>An object with several options for the new element (properties, attributes, events etc). For details about what options this object accepts, see <code>$.set()</code>. If <code>tag</code> is omitted, you need to provide it in the <code>options</code> object.</dd>
 
 			<dt class="element">element</dt>
 			<dd>The newly created element.</dd>


### PR DESCRIPTION
The name of the property on `Element` is `tagName`, but it is referenced as `tag` both previously in this doc and as the name of the property to be passed in as an option to `$.set`.