### PR TITLE
Test the $.set method

### DIFF
--- a/tests/CoreSpec.js
+++ b/tests/CoreSpec.js
@@ -7,7 +7,6 @@ describe("Core Bliss", function () {
 
 	beforeEach(function () {
 		this.fixture = fixture.load('core.html');
-		document.body.innerHTML += this.fixture[0];
 	});
 
 	// testing setup

--- a/tests/CoreSpec.js
+++ b/tests/CoreSpec.js
@@ -1,8 +1,11 @@
 describe("Core Bliss", function () {
 	"use strict";
 
-	beforeEach(function () {
+	before(function() {
 		fixture.setBase('tests/fixtures');
+	});
+
+	beforeEach(function () {
 		this.fixture = fixture.load('core.html');
 		document.body.innerHTML += this.fixture[0];
 	});

--- a/tests/CoreSpec.js
+++ b/tests/CoreSpec.js
@@ -13,9 +13,9 @@ describe("Core Bliss", function () {
 	});
 
 	it("has global methods and aliases", function() {
-		expect(Bliss).to.be.defined;
-		expect($).to.be.defined;
-		expect($$).to.be.defined;
+		expect(Bliss).to.exist;
+		expect($).to.exist;
+		expect($$).to.exist;
 
 		expect($).to.equal(Bliss);
 		expect($$).to.equal($.$);

--- a/tests/DOM/SetSpec.js
+++ b/tests/DOM/SetSpec.js
@@ -21,6 +21,20 @@ describe("$.set", function() {
 		expect(element.className).to.equal("main-navigation");
 	});
 
+	xit("can be called on arrays", function() {
+		var list = [
+			document.createElement("li"),
+			document.createElement("li"),
+			document.createElement("li")
+		];
+
+		list._.set({className: "list-part"});
+
+		list.forEach(function(item) {
+			expect(item.className).to.equal("list-part");
+		});
+	});
+
 	it("sets other options as properties or attributes on the subject", function() {
 		var element = $.set(document.createElement("input"), {
 			id: "the-main-one",

--- a/tests/DOM/SetSpec.js
+++ b/tests/DOM/SetSpec.js
@@ -1,0 +1,16 @@
+describe("$.set", function() {
+	it("exists", function() {
+		expect($.set).to.exist;
+	});
+
+	it("sets options on the provided subject", function() {
+		var element = $.set(document.createElement("nav"), {
+			style: {
+				color: "red"
+			}
+		});
+
+		expect(element).to.exist;
+		expect(element.style.color).to.equal("red");
+	});
+});

--- a/tests/DOM/SetSpec.js
+++ b/tests/DOM/SetSpec.js
@@ -13,4 +13,23 @@ describe("$.set", function() {
 		expect(element).to.exist;
 		expect(element.style.color).to.equal("red");
 	});
+
+	it("can be called on elements", function() {
+		var element = document.createElement("nav");
+		element._.set({className: "main-navigation"});
+
+		expect(element.className).to.equal("main-navigation");
+	});
+
+	it("sets other options as properties or attributes on the subject", function() {
+		var element = $.set(document.createElement("input"), {
+			id: "the-main-one",
+			type: "text",
+			disabled: true
+		});
+
+		expect(element.id).to.equal("the-main-one");
+		expect(element.disabled).to.be.true;
+		expect(element.type).to.equal("text");
+	});
 });


### PR DESCRIPTION
This adds tests for the features that are unique to the `$.set` method, namely that it automatically sets properties and attributes.

It also cleans up some of the test setup related to fixtures, and includes a failing test for calling `set` on arrays. Issue incoming for that.