### PR TITLE
Add linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,31 @@
+{
+	"env": {
+		"browser": true
+	},
+	"globals": {
+		"Bliss": true,
+		"$$": true
+	},
+	"rules": {
+		"brace-style": [2, "stroustrup", {
+			"allowSingleLine": true
+		}],
+		"camelcase": [2, {
+			"properties": "always"
+		}],
+		"comma-dangle": 2,
+    "comma-style": [2, "last"],
+		"eol-last": 2,
+		"indent": [2, "tab"],
+    "key-spacing": [2, {
+      "beforeColon": false,
+      "afterColon": true
+    }],
+    "no-mixed-spaces-and-tabs": 2,
+    "no-multiple-empty-lines": 2,
+    "no-multi-spaces": 2,
+    "no-redeclare": 2,
+    "no-undef": 2,
+    "quotes": [2, "double", "avoid-escape"]
+	}
+}

--- a/bliss._.js
+++ b/bliss._.js
@@ -1,91 +1,92 @@
 (function($) {
-"use strict";
 
-if (!Bliss || Bliss.shy) {
-	return;
-}
+	"use strict";
 
-var _ = Bliss.property;
-
-// Methods requiring Bliss Full
-$.add({
-	// Clone elements, with events
-	clone: function () {
-		var clone = this.cloneNode(true);
-		var descendants = $.$("*", clone).concat(clone);
-
-		$.$("*", this).concat(this).forEach(function(element, i, arr) {
-			$.events(descendants[i], element);
-		});
-
-		return clone;
+	if (!Bliss || Bliss.shy) {
+		return;
 	}
-}, {array: false});
 
-// Define the _ property on arrays and elements
+	var _ = Bliss.property;
 
-Object.defineProperty(Node.prototype, _, {
-	get: function () {
-		Object.defineProperty(this, _, {
-			value: new $.Element(this)
-		});
-		
-		return this[_];
-	},
-	configurable: true
-});
+	// Methods requiring Bliss Full
+	$.add({
+		// Clone elements, with events
+		clone: function () {
+			var clone = this.cloneNode(true);
+			var descendants = $.$("*", clone).concat(clone);
 
-Object.defineProperty(Array.prototype, _, {
-	get: function () {
-		Object.defineProperty(this, _, {
-			value: new $.Array(this)
-		});
-		
-		return this[_];
-	},
-	configurable: true
-});
+			$.$("*", this).concat(this).forEach(function(element, i, arr) {
+				$.events(descendants[i], element);
+			});
 
-// Hijack addEventListener and removeEventListener to store callbacks
+			return clone;
+		}
+	}, {array: false});
 
-if (self.EventTarget && "addEventListener" in EventTarget.prototype) {
-	var addEventListener = EventTarget.prototype.addEventListener,
-	    removeEventListener = EventTarget.prototype.removeEventListener,
-	    filter = function(callback, capture, l){
-	    	return !(l.callback === callback && l.capture == capture);
-	    };
+	// Define the _ property on arrays and elements
 
-	EventTarget.prototype.addEventListener = function(type, callback, capture) {
-		if (this[_] && callback) {
-			var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
-			
-			listeners[type] = listeners[type] || [];
-			
-			if (listeners[type].filter(filter.bind(null, callback, capture)).length === 0) {
-				listeners[type].push({callback: callback, capture: capture});
+	Object.defineProperty(Node.prototype, _, {
+		get: function () {
+			Object.defineProperty(this, _, {
+				value: new $.Element(this)
+			});
+
+			return this[_];
+		},
+		configurable: true
+	});
+
+	Object.defineProperty(Array.prototype, _, {
+		get: function () {
+			Object.defineProperty(this, _, {
+				value: new $.Array(this)
+			});
+
+			return this[_];
+		},
+		configurable: true
+	});
+
+	// Hijack addEventListener and removeEventListener to store callbacks
+
+	if (self.EventTarget && "addEventListener" in EventTarget.prototype) {
+		var addEventListener = EventTarget.prototype.addEventListener,
+			removeEventListener = EventTarget.prototype.removeEventListener,
+			filter = function(callback, capture, l){
+				return !(l.callback === callback && l.capture == capture);
+			};
+
+		EventTarget.prototype.addEventListener = function(type, callback, capture) {
+			if (this[_] && callback) {
+				var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
+
+				listeners[type] = listeners[type] || [];
+
+				if (listeners[type].filter(filter.bind(null, callback, capture)).length === 0) {
+					listeners[type].push({callback: callback, capture: capture});
+				}
 			}
-		}
 
-		return addEventListener.call(this, type, callback, capture);
-	};
+			return addEventListener.call(this, type, callback, capture);
+		};
 
-	EventTarget.prototype.removeEventListener = function(type, callback, capture) {
-		if (this[_] && callback) {
-			var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
+		EventTarget.prototype.removeEventListener = function(type, callback, capture) {
+			if (this[_] && callback) {
+				var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
 
-			var oldCallback = callback;
-			callback = oldCallback.callback;
+				var oldCallback = callback;
+				callback = oldCallback.callback;
 
-			listeners[type] = listeners[type] || [];
-			listeners[type] = listeners[type].filter(filter.bind(null, callback, capture));
-		}
+				listeners[type] = listeners[type] || [];
+				listeners[type] = listeners[type].filter(filter.bind(null, callback, capture));
+			}
 
-		return removeEventListener.call(this, type, callback, capture);
-	};
-}
+			return removeEventListener.call(this, type, callback, capture);
+		};
+	}
 
-// Set $ and $$ convenience methods, if not taken
-self.$ = self.$ || $;
-self.$$ = self.$$ || $.$;
+	// Set $ and $$ convenience methods, if not taken
+	self.$ = self.$ || $;
+	self.$$ = self.$$ || $.$;
 
 })(Bliss);

--- a/bliss.js
+++ b/bliss.js
@@ -609,93 +609,94 @@
 })();
 
 (function($) {
-"use strict";
 
-if (!Bliss || Bliss.shy) {
-	return;
-}
+	"use strict";
 
-var _ = Bliss.property;
-
-// Methods requiring Bliss Full
-$.add({
-	// Clone elements, with events
-	clone: function () {
-		var clone = this.cloneNode(true);
-		var descendants = $.$("*", clone).concat(clone);
-
-		$.$("*", this).concat(this).forEach(function(element, i, arr) {
-			$.events(descendants[i], element);
-		});
-
-		return clone;
+	if (!Bliss || Bliss.shy) {
+		return;
 	}
-}, {array: false});
 
-// Define the _ property on arrays and elements
+	var _ = Bliss.property;
 
-Object.defineProperty(Node.prototype, _, {
-	get: function () {
-		Object.defineProperty(this, _, {
-			value: new $.Element(this)
-		});
-		
-		return this[_];
-	},
-	configurable: true
-});
+	// Methods requiring Bliss Full
+	$.add({
+		// Clone elements, with events
+		clone: function () {
+			var clone = this.cloneNode(true);
+			var descendants = $.$("*", clone).concat(clone);
 
-Object.defineProperty(Array.prototype, _, {
-	get: function () {
-		Object.defineProperty(this, _, {
-			value: new $.Array(this)
-		});
-		
-		return this[_];
-	},
-	configurable: true
-});
+			$.$("*", this).concat(this).forEach(function(element, i, arr) {
+				$.events(descendants[i], element);
+			});
 
-// Hijack addEventListener and removeEventListener to store callbacks
+			return clone;
+		}
+	}, {array: false});
 
-if (self.EventTarget && "addEventListener" in EventTarget.prototype) {
-	var addEventListener = EventTarget.prototype.addEventListener,
-	    removeEventListener = EventTarget.prototype.removeEventListener,
-	    filter = function(callback, capture, l){
-	    	return !(l.callback === callback && l.capture == capture);
-	    };
+	// Define the _ property on arrays and elements
 
-	EventTarget.prototype.addEventListener = function(type, callback, capture) {
-		if (this[_] && callback) {
-			var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
-			
-			listeners[type] = listeners[type] || [];
-			
-			if (listeners[type].filter(filter.bind(null, callback, capture)).length === 0) {
-				listeners[type].push({callback: callback, capture: capture});
+	Object.defineProperty(Node.prototype, _, {
+		get: function () {
+			Object.defineProperty(this, _, {
+				value: new $.Element(this)
+			});
+
+			return this[_];
+		},
+		configurable: true
+	});
+
+	Object.defineProperty(Array.prototype, _, {
+		get: function () {
+			Object.defineProperty(this, _, {
+				value: new $.Array(this)
+			});
+
+			return this[_];
+		},
+		configurable: true
+	});
+
+	// Hijack addEventListener and removeEventListener to store callbacks
+
+	if (self.EventTarget && "addEventListener" in EventTarget.prototype) {
+		var addEventListener = EventTarget.prototype.addEventListener,
+			removeEventListener = EventTarget.prototype.removeEventListener,
+			filter = function(callback, capture, l){
+				return !(l.callback === callback && l.capture == capture);
+			};
+
+		EventTarget.prototype.addEventListener = function(type, callback, capture) {
+			if (this[_] && callback) {
+				var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
+
+				listeners[type] = listeners[type] || [];
+
+				if (listeners[type].filter(filter.bind(null, callback, capture)).length === 0) {
+					listeners[type].push({callback: callback, capture: capture});
+				}
 			}
-		}
 
-		return addEventListener.call(this, type, callback, capture);
-	};
+			return addEventListener.call(this, type, callback, capture);
+		};
 
-	EventTarget.prototype.removeEventListener = function(type, callback, capture) {
-		if (this[_] && callback) {
-			var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
+		EventTarget.prototype.removeEventListener = function(type, callback, capture) {
+			if (this[_] && callback) {
+				var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
 
-			var oldCallback = callback;
-			callback = oldCallback.callback;
+				var oldCallback = callback;
+				callback = oldCallback.callback;
 
-			listeners[type] = listeners[type] || [];
-			listeners[type] = listeners[type].filter(filter.bind(null, callback, capture));
-		}
+				listeners[type] = listeners[type] || [];
+				listeners[type] = listeners[type].filter(filter.bind(null, callback, capture));
+			}
 
-		return removeEventListener.call(this, type, callback, capture);
-	};
-}
+			return removeEventListener.call(this, type, callback, capture);
+		};
+	}
 
-// Set $ and $$ convenience methods, if not taken
-self.$ = self.$ || $;
-self.$$ = self.$$ || $.$;
+	// Set $ and $$ convenience methods, if not taken
+	self.$ = self.$ || $;
+	self.$$ = self.$$ || $.$;
 
 })(Bliss);

--- a/bliss.js
+++ b/bliss.js
@@ -1,608 +1,613 @@
 (function() {
-"use strict";
 
-// Copy properties from one object to another. Overwrites allowed.
-function extend(to, from, whitelist) {
-	for (var property in from) {
-		if (whitelist) {
-			var type = $.type(whitelist);
+	"use strict";
 
-			if (whitelist === "own" && !from.hasOwnProperty(property) ||
-				type === "array" && whitelist.indexOf(property) === -1 ||
-				type === "regexp" && !whitelist.test(property) ||
-				type === "function" && !whitelist.call(from, property)) {
-				continue;
+	// Copy properties from one object to another. Overwrites allowed.
+	function extend(to, from, whitelist) {
+		for (var property in from) {
+			if (whitelist) {
+				var type = $.type(whitelist);
+
+				if (whitelist === "own" && !from.hasOwnProperty(property) ||
+					type === "array" && whitelist.indexOf(property) === -1 ||
+					type === "regexp" && !whitelist.test(property) ||
+					type === "function" && !whitelist.call(from, property)) {
+					continue;
+				}
 			}
-		}
 
-		// To copy gettters/setters, preserve flags etc
-		var descriptor = Object.getOwnPropertyDescriptor(from, property);
+			// To copy gettters/setters, preserve flags etc
+			var descriptor = Object.getOwnPropertyDescriptor(from, property);
 
-		if (descriptor && (!descriptor.writable || !descriptor.configurable || !descriptor.enumerable || descriptor.get || descriptor.set)) {
-			delete to[property];
-			Object.defineProperty(to, property, descriptor);
-		}
-		else {
-			to[property] = from[property];
-		}
-	}
-	
-	return to;
-};
-
-var $ = self.Bliss = extend(function(expr, context) {
-	return $.type(expr) === "string"? (context || document).querySelector(expr) : expr || null;
-}, self.Bliss);
-
-extend($, {
-	extend: extend,
-
-	property: $.property || "_",
-
-	sources: {},
-
-	$: function(expr, context) {
-		return expr instanceof Node || expr instanceof Window? [expr] :
-		       [].slice.call(typeof expr == "string"? (context || document).querySelectorAll(expr) : expr || []);
-	},
-	
-	/**
-	 * Returns the [[Class]] of an object in lowercase (eg. array, date, regexp, string etc)
-	 */
-	type: function(obj) {
-		if (obj === null) { return 'null'; }
-	
-		if (obj === undefined) { return 'undefined'; }
-	
-		var ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
-	
-		if(ret == 'number' && isNaN(obj)) {
-			return 'nan';
-		}
-	
-		return ret;
-	},
-	
-	/*
-	 * Return first non-undefined value. Mainly used internally.
-	 */
-	defined: function () {
-		for (var i=0; i<arguments.length; i++) {
-			if (arguments[i] !== undefined) {
-				return arguments[i];
-			}
-		}
-	},
-	
-	create: function (tag, o) {
-		if (arguments.length === 1) {
-			if ($.type(tag) === "string") {
-				return document.createTextNode(tag);
-			}
-			
-			o = tag;
-			tag = o.tag;			
-		}
-
-		delete o.tag;
-		
-		return $.set(document.createElement(tag || "div"), o);
-	},
-
-	ready: function(context) {
-		context = context || document;
-
-		return new Promise(function(resolve, reject){
-			if (context.readyState !== "loading") {
-				resolve();
+			if (descriptor && (!descriptor.writable || !descriptor.configurable || !descriptor.enumerable || descriptor.get || descriptor.set)) {
+				delete to[property];
+				Object.defineProperty(to, property, descriptor);
 			}
 			else {
-				context.addEventListener("DOMContentLoaded", function(){
-					resolve();
-				});
-			}
-		});
-	},
-
-	// Helper for defining OOP-like “classes”
-	Class: function(o) {
-		var init = o.constructor || function(){};
-		delete o.constructor;
-
-		var abstract = o.abstract;
-		delete o.abstract;
-
-		var ret = function() {
-			if (abstract && this.constructor === ret) {
-				throw new Error("Abstract classes cannot be directly instantiated.");
-			}
-
-			if (this.constructor.super && this.constructor.super != ret) {
-				// FIXME This should never happen, but for some reason it does if ret.super is null
-				// Debugging revealed that somehow this.constructor !== ret, wtf. Must look more into this
-				this.constructor.super.apply(this, arguments);
-			}
-
-			return init.apply(this, arguments);
-		};
-
-		ret.super = o.extends || null;
-		delete o.extends;
-
-		ret.prototype = $.extend(Object.create(ret.super && ret.super.prototype), {
-			constructor: ret
-		});
-
-		$.extend(ret, o.static);
-		delete o.static;
-
-		for (var property in o) {
-			if (property in $.classProps) {
-				$.classProps[property].call(ret, ret.prototype, o[property]);
-				delete o[property];
+				to[property] = from[property];
 			}
 		}
 
-		// Anything that remains is an instance method/property or ret.prototype.constructor
-		$.extend(ret.prototype, o);
+		return to;
+	};
 
-		// For easier calling of super methods
-		// This doesn't save us from having to use .call(this) though
-		ret.prototype.super = ret.super? ret.super.prototype : null;
-		
-		return ret;
-	},
+	var $ = self.Bliss = extend(function(expr, context) {
+		return $.type(expr) === "string"? (context || document).querySelector(expr) : expr || null;
+	}, self.Bliss);
 
-	// Properties with special handling in classes
-	classProps: {
-		// Lazily evaluated properties
-		lazy: function(obj, property, getter) {
-			if (arguments.length >= 3) {
-				Object.defineProperty(obj, property, {
-					get: function() {
-						// FIXME this does not work for instances if property is defined on the prototype
-						delete this[property];
+	extend($, {
+		extend: extend,
 
-						try { this[property] = 5;
-						} catch(e) {console.error(e)}
+		property: $.property || "_",
 
-						return this[property] = getter.call(this);
-					},
-					configurable: true,
-					enumerable: true
-				});
-			}
-			else if (arguments.length === 2) {
-				for (var prop in property) {
-					$.lazy(obj, prop, property[prop]);
-				}
-			}
+		sources: {},
 
-			return obj;
+		$: function(expr, context) {
+			return expr instanceof Node || expr instanceof Window? [expr] :
+						[].slice.call(typeof expr == "string"? (context || document).querySelectorAll(expr) : expr || []);
 		},
 
-		// Properties that behave like normal properties but also execute code upon getting/setting
-		live: function(obj, property, descriptor) {
-			if (arguments.length >= 3) {
-				Object.defineProperty(obj, property, {
-					get: function() {
-						var value = this["_" + property];
-						var ret = descriptor.get && descriptor.get.call(this, value);
-						return ret !== undefined? ret : value;
-					},
-					set: function(v) {
-						var value = this["_" + property];
-						var ret = descriptor.set && descriptor.set.call(this, v, value);
-						this["_" + property] = ret !== undefined? ret : v;
-					},
-					configurable: descriptor.configurable,
-					enumerable: descriptor.enumerable
-				});
-			}
-			else if (arguments.length === 2) {
-				for (var prop in property) {
-					$.live(obj, prop, property[prop]);
-				}
+		/**
+		* Returns the [[Class]] of an object in lowercase (eg. array, date, regexp, string etc)
+		*/
+		type: function(obj) {
+			if (obj === null) { return "null"; }
+
+			if (obj === undefined) { return "undefined"; }
+
+			var ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
+
+			if(ret == "number" && isNaN(obj)) {
+				return "nan";
 			}
 
-			return obj;
+			return ret;
 		},
-	},
 
-	// Includes a script, returns a promise
-	include: function() {
-		var url = arguments[arguments.length - 1];
-		var loaded = arguments.length === 2? arguments[0] : false;
-
-		var script = document.createElement("script");
-
-		return loaded? Promise.resolve() : new Promise(function(resolve, reject){
-			$.set(script, {
-				async: true,
-				onload: function() {
-					resolve();
-					$.remove(script);
-				},
-				onerror: function() {
-					reject();
-				},
-				src: url,
-				inside: document.head
-			});
-		});
-		
-	},
-
-	/*
-	 * Fetch API inspired XHR wrapper. Returns promise.
-	 */
-	fetch: function(url, o) {
-		if (!url) {
-			throw new TypeError("URL parameter is mandatory and cannot be " + url);
-		}
-
-		// Set defaults & fixup arguments
-		url = new URL(url, location);
-		o = o || {};
-		o.data = o.data || '';
-		o.method = o.method || 'GET';
-		o.headers = o.headers || {};
-
-		var xhr = new XMLHttpRequest();
-
-		if ($.type(o.data) !== "string") {
-			o.data = Object.keys(o.data).map(function(key){ return key + "=" + encodeURIComponent(o.data[key])}).join("&");
-		}
-
-		if (o.method === "GET" && o.data) {
-			url.search += o.data;
-		}
-		
-		document.body.setAttribute('data-loading', url);
-		
-		xhr.open(o.method, url, !o.sync);
-
-		for (var property in o) {
-			if (property in xhr) {
-				try {
-					xhr[property] = o[property];
-				}
-				catch (e) {
-					self.console && console.error(e);
+		/*
+		* Return first non-undefined value. Mainly used internally.
+		*/
+		defined: function () {
+			for (var i=0; i<arguments.length; i++) {
+				if (arguments[i] !== undefined) {
+					return arguments[i];
 				}
 			}
-		}
-		
-		if (o.method !== 'GET' && !o.headers['Content-type'] && !o.headers['Content-Type']) {
-			xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-		}
-		
-		for (var header in o.headers) {
-			xhr.setRequestHeader(header, o.headers[header]);
-		}
-		
-		return new Promise(function(resolve, reject){
-			xhr.onload = function(){
-				document.body.removeAttribute('data-loading');
-					
-				if (xhr.status === 0 || xhr.status >= 200 && xhr.status < 300 || xhr.status === 304) {
-					// Success!
-					resolve(xhr);
+		},
+
+		create: function (tag, o) {
+			if (arguments.length === 1) {
+				if ($.type(tag) === "string") {
+					return document.createTextNode(tag);
+				}
+
+				o = tag;
+				tag = o.tag;
+			}
+
+			delete o.tag;
+
+			return $.set(document.createElement(tag || "div"), o);
+		},
+
+		ready: function(context) {
+			context = context || document;
+
+			return new Promise(function(resolve, reject){
+				if (context.readyState !== "loading") {
+					resolve();
 				}
 				else {
-					reject(Error(xhr.statusText));
-				}
-			
-			};
-			
-			xhr.onerror = function() {
-				document.body.removeAttribute('data-loading');
-				reject(Error("Network Error"));
-			};
-
-			xhr.send(o.method === 'GET'? null : o.data);
-		});
-	}
-});
-
-var _ = $.property;
-
-$.Element = function (subject) {
-	this.subject = subject;
-
-	// Author-defined element-related data
-	this.data = {};
-
-	// Internal Bliss element-related data
-	this.bliss = {};
-};
-
-$.Element.prototype = {
-	set: function (properties) {
-		if ($.type(arguments[0]) === "string") {
-			properties = {};
-			properties[arguments[0]] = arguments[1];
-		}
-
-		for (var property in properties) {
-			if (property in $.setProps) {
-				$.setProps[property].call(this, properties[property]);
-			}
-			else if (property in this) {
-				this[property] = properties[property];
-			}
-			else {
-				if (!this.setAttribute) {
-					console.log(this);
-				}
-				this.setAttribute(property, properties[property]);
-			}
-		}
-	},
-
-	// Run a CSS transition, return promise
-	transition: function(props, duration) {
-		duration = +duration || 400;
-
-		return new Promise(function(resolve, reject){
-			if ("transition" in this.style) {
-				// Get existing style
-				var previous = $.extend({}, this.style, /^transition(Duration|Property)$/);
-
-				$.style(this, {
-					transitionDuration: (duration || 400) + "ms",
-					transitionProperty: Object.keys(props).join(", ")
-				});
-
-				$.once(this, "transitionend", function(){
-					clearTimeout(i);
-					$.style(this, previous);
-					resolve(this);
-				});
-
-				// Failsafe, in case transitionend doesn’t fire
-				var i = setTimeout(resolve, duration+50, this);
-
-				$.style(this, props);
-			}
-			else {
-				$.style(this, props);
-				resolve(this);
-			}
-		}.bind(this));
-	},
-	
-	// Fire a synthesized event on the element
-	fire: function (type, properties) {
-		var evt = document.createEvent("HTMLEvents");
-				
-		evt.initEvent(type, true, true );
-
-		this.dispatchEvent($.extend(evt, properties));
-	}
-};
-
-/*
- * Properties with custom handling in $.set()
- * Also available as functions directly on element._ and on $
- */
-$.setProps = {
-	// Set a bunch of inline CSS styles
-	style: function (val) {
-		$.extend(this.style, val);
-	},
-	
-	// Set a bunch of attributes
-	attributes: function (o) {
-		for (var attribute in o) {
-			this.setAttribute(attribute, o[attribute]);
-		}
-	},
-	
-	// Set a bunch of properties on the element
-	properties: function (val) {
-		$.extend(this, val);
-	},
-	
-	// Bind one or more events to the element
-	events: function (val) {
-		if (val instanceof EventTarget) {
-			// Copy events from other element (requires Bliss Full)
-			var me = this;
-
-			// Copy listeners
-			if (val[_] && val[_].bliss) {
-				var listeners = val[_].bliss.listeners;
-
-				for (var type in listeners) {
-					listeners[type].forEach(function(l){
-						me.addEventListener(type, l.callback, l.capture);
+					context.addEventListener("DOMContentLoaded", function(){
+						resolve();
 					});
 				}
-			}
+			});
+		},
 
-			// Copy inline events
-			for (var onevent in val) {
-				if (onevent.indexOf("on") === 0) {
-					this[onevent] = val[onevent];
+		// Helper for defining OOP-like “classes”
+		Class: function(o) {
+			var init = o.constructor || function(){};
+			delete o.constructor;
+
+			var abstract = o.abstract;
+			delete o.abstract;
+
+			var ret = function() {
+				if (abstract && this.constructor === ret) {
+					throw new Error("Abstract classes cannot be directly instantiated.");
+				}
+
+				if (this.constructor.super && this.constructor.super != ret) {
+					// FIXME This should never happen, but for some reason it does if ret.super is null
+					// Debugging revealed that somehow this.constructor !== ret, wtf. Must look more into this
+					this.constructor.super.apply(this, arguments);
+				}
+
+				return init.apply(this, arguments);
+			};
+
+			ret.super = o.extends || null;
+			delete o.extends;
+
+			ret.prototype = $.extend(Object.create(ret.super && ret.super.prototype), {
+				constructor: ret
+			});
+
+			$.extend(ret, o.static);
+			delete o.static;
+
+			for (var property in o) {
+				if (property in $.classProps) {
+					$.classProps[property].call(ret, ret.prototype, o[property]);
+					delete o[property];
 				}
 			}
-		}
-		else {
-			for (var events in val) {
-				events.split(/\s+/).forEach(function (event) {
-					this.addEventListener(event, val[events]);
-				}, this);
-			}
-		}
-	},
 
-	once: function(val) {
-		if (arguments.length == 2) {
-			val = {};
-			val[arguments[0]] = arguments[1];
-		}
+			// Anything that remains is an instance method/property or ret.prototype.constructor
+			$.extend(ret.prototype, o);
 
-		for (var events in val) {
-			events.split(/\s+/).forEach(function (event) {
-				var me = this;
-				this.addEventListener(event, function callback() {
-					me.removeEventListener(event, callback);
-					return val[events].apply(this, arguments);
-				});
-			}, this);
-		}
-	},
+			// For easier calling of super methods
+			// This doesn't save us from having to use .call(this) though
+			ret.prototype.super = ret.super? ret.super.prototype : null;
 
-	// Event delegation
-	delegate: function(val) {
-		if (arguments.length === 3) {
-			// Called with ("type", "selector", callback)
-			val = {};
-			val[arguments[0]] = {};
-			val[arguments[0]][arguments[1]] = arguments[2];
-		}
-		else if (arguments.length === 2) {
-			// Called with ("type", selectors & callbacks)
-			val = {};
-			val[arguments[0]] = arguments[1];
-		}
+			return ret;
+		},
 
-		var element = this;
+		// Properties with special handling in classes
+		classProps: {
+			// Lazily evaluated properties
+			lazy: function(obj, property, getter) {
+				if (arguments.length >= 3) {
+					Object.defineProperty(obj, property, {
+						get: function() {
+							// FIXME this does not work for instances if property is defined on the prototype
+							delete this[property];
 
-		for (var type in val) {
-			(function (type, callbacks) {
-				element.addEventListener(type, function(evt) {
-					for (var selector in callbacks) {
-						if (evt.target.matches(selector)) { // Do ancestors count?
-							callbacks[selector].call(this, evt);
-						}
-					}	
-				});
-			})(type, val[type]);
-		}
-	},
-	
-	// Set the contents as a string, an element, an object to create an element or an array of these
-	contents: function (val) {
-		if (val || val === 0) {
-			(Array.isArray(val)? val : [val]).forEach(function (child) {
-				if (/^(string|number|object)$/.test($.type(child))) {
-					child = $.create(child);
-				}
-				
-				if (child instanceof Node) {
-					this.appendChild(child);
-				}
-			}, this);
-		}
-	},
-	
-	// Append the element inside another element
-	inside: function (element) {
-		element.appendChild(this);
-	},
-	
-	// Insert the element before another element
-	before: function (element) {
-		element.parentNode.insertBefore(this, element);
-	},
-	
-	// Insert the element after another element
-	after: function (element) {
-		element.parentNode.insertBefore(this, element.nextSibling);
-	},
-	
-	// Insert the element before another element's contents
-	start: function (element) {
-		element.insertBefore(this, element.firstChild);
-	},
-	
-	// Wrap the element around another element
-	around: function (element) {
-		if (element.parentNode) {
-			$.before(this, element);
-		}
-		
-		(/^template$/i.test(this.nodeName)? this.content || this : this).appendChild(element);
-	}
-};
+							try {
+								this[property] = 5;
+							}
+							catch(e) {
+								console.error(e)
+							}
 
-$.Array = function (subject) {
-	this.subject = subject;
-};
-
-$.Array.prototype = {
-	all: function(method) {
-		var args = $$(arguments).slice(1);
-
-		return this[method].apply(this, args);
-	}
-};
-
-// Extends Bliss with more methods
-$.add = function (methods, on, noOverwrite) {
-	on = $.extend({$: true, element: true, array: true}, on);
-	
-	if ($.type(arguments[0]) === "string") {
-		methods = {};
-		methods[arguments[0]] = arguments[1];
-	}
-	
-	for (var method in methods) {
-
-		try {
-			var callback = methods[method];
-		}
-		catch (e) {
-			continue;
-		}
-		
-		(function(method, callback){
-
-		
-		if ($.type(callback) == "function") {
-			if (on.element && (!(method in $.Element.prototype) || !noOverwrite)) {
-				$.Element.prototype[method] = function () {
-					return this.subject && $.defined(callback.apply(this.subject, arguments), this.subject);
-				};
-			}
-
-			if (on.array && (!(method in $.Array.prototype) || !noOverwrite)) {
-				$.Array.prototype[method] = function() {
-					var args = arguments;
-					return this.subject.map(function(element) {
-						return element && $.defined(callback.apply(element, args), element);
+							return this[property] = getter.call(this);
+						},
+						configurable: true,
+						enumerable: true
 					});
-				};
+				}
+				else if (arguments.length === 2) {
+					for (var prop in property) {
+						$.lazy(obj, prop, property[prop]);
+					}
+				}
+
+				return obj;
+			},
+
+			// Properties that behave like normal properties but also execute code upon getting/setting
+			live: function(obj, property, descriptor) {
+				if (arguments.length >= 3) {
+					Object.defineProperty(obj, property, {
+						get: function() {
+							var value = this["_" + property];
+							var ret = descriptor.get && descriptor.get.call(this, value);
+							return ret !== undefined? ret : value;
+						},
+						set: function(v) {
+							var value = this["_" + property];
+							var ret = descriptor.set && descriptor.set.call(this, v, value);
+							this["_" + property] = ret !== undefined? ret : v;
+						},
+						configurable: descriptor.configurable,
+						enumerable: descriptor.enumerable
+					});
+				}
+				else if (arguments.length === 2) {
+					for (var prop in property) {
+						$.live(obj, prop, property[prop]);
+					}
+				}
+
+				return obj;
+			}
+		},
+
+		// Includes a script, returns a promise
+		include: function() {
+			var url = arguments[arguments.length - 1];
+			var loaded = arguments.length === 2? arguments[0] : false;
+
+			var script = document.createElement("script");
+
+			return loaded? Promise.resolve() : new Promise(function(resolve, reject){
+				$.set(script, {
+					async: true,
+					onload: function() {
+						resolve();
+						$.remove(script);
+					},
+					onerror: function() {
+						reject();
+					},
+					src: url,
+					inside: document.head
+				});
+			});
+
+		},
+
+		/*
+		* Fetch API inspired XHR wrapper. Returns promise.
+		*/
+		fetch: function(url, o) {
+			if (!url) {
+				throw new TypeError("URL parameter is mandatory and cannot be " + url);
 			}
 
-			if (on.$) {
-				$.sources[method] = $[method] = callback;
+			// Set defaults & fixup arguments
+			url = new URL(url, location);
+			o = o || {};
+			o.data = o.data || "";
+			o.method = o.method || "GET";
+			o.headers = o.headers || {};
 
-				if (on.array || on.element) {
-					$[method] = function () {
-						var args = [].slice.apply(arguments);
-						var subject = args.shift();
-						var Type = on.array && Array.isArray(subject)? "Array" : "Element";
+			var xhr = new XMLHttpRequest();
 
-						return $[Type].prototype[method].apply({subject: subject}, args);
+			if ($.type(o.data) !== "string") {
+				o.data = Object.keys(o.data).map(function(key){ return key + "=" + encodeURIComponent(o.data[key])}).join("&");
+			}
+
+			if (o.method === "GET" && o.data) {
+				url.search += o.data;
+			}
+
+			document.body.setAttribute("data-loading", url);
+
+			xhr.open(o.method, url, !o.sync);
+
+			for (var property in o) {
+				if (property in xhr) {
+					try {
+						xhr[property] = o[property];
+					}
+					catch (e) {
+						self.console && console.error(e);
 					}
 				}
 			}
-		}
-		
-		})(method, callback);
-	}
-};
 
-$.add($.Array.prototype, {element: false});
-$.add($.Element.prototype);
-$.add($.setProps);
-$.add($.classProps, {element: false, array: false});
-$.add(HTMLElement.prototype, null, true);
+			if (o.method !== "GET" && !o.headers["Content-type"] && !o.headers["Content-Type"]) {
+				xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+			}
+
+			for (var header in o.headers) {
+				xhr.setRequestHeader(header, o.headers[header]);
+			}
+
+			return new Promise(function(resolve, reject){
+				xhr.onload = function(){
+					document.body.removeAttribute("data-loading");
+
+					if (xhr.status === 0 || xhr.status >= 200 && xhr.status < 300 || xhr.status === 304) {
+						// Success!
+						resolve(xhr);
+					}
+					else {
+						reject(Error(xhr.statusText));
+					}
+
+				};
+
+				xhr.onerror = function() {
+					document.body.removeAttribute("data-loading");
+					reject(Error("Network Error"));
+				};
+
+				xhr.send(o.method === "GET"? null : o.data);
+			});
+		}
+	});
+
+	var _ = $.property;
+
+	$.Element = function (subject) {
+		this.subject = subject;
+
+		// Author-defined element-related data
+		this.data = {};
+
+		// Internal Bliss element-related data
+		this.bliss = {};
+	};
+
+	$.Element.prototype = {
+		set: function (properties) {
+			if ($.type(arguments[0]) === "string") {
+				properties = {};
+				properties[arguments[0]] = arguments[1];
+			}
+
+			for (var property in properties) {
+				if (property in $.setProps) {
+					$.setProps[property].call(this, properties[property]);
+				}
+				else if (property in this) {
+					this[property] = properties[property];
+				}
+				else {
+					if (!this.setAttribute) {
+						console.log(this);
+					}
+					this.setAttribute(property, properties[property]);
+				}
+			}
+		},
+
+		// Run a CSS transition, return promise
+		transition: function(props, duration) {
+			duration = +duration || 400;
+
+			return new Promise(function(resolve, reject){
+				if ("transition" in this.style) {
+					// Get existing style
+					var previous = $.extend({}, this.style, /^transition(Duration|Property)$/);
+
+					$.style(this, {
+						transitionDuration: (duration || 400) + "ms",
+						transitionProperty: Object.keys(props).join(", ")
+					});
+
+					$.once(this, "transitionend", function(){
+						clearTimeout(i);
+						$.style(this, previous);
+						resolve(this);
+					});
+
+					// Failsafe, in case transitionend doesn’t fire
+					var i = setTimeout(resolve, duration+50, this);
+
+					$.style(this, props);
+				}
+				else {
+					$.style(this, props);
+					resolve(this);
+				}
+			}.bind(this));
+		},
+
+		// Fire a synthesized event on the element
+		fire: function (type, properties) {
+			var evt = document.createEvent("HTMLEvents");
+
+			evt.initEvent(type, true, true );
+
+			this.dispatchEvent($.extend(evt, properties));
+		}
+	};
+
+	/*
+	* Properties with custom handling in $.set()
+	* Also available as functions directly on element._ and on $
+	*/
+	$.setProps = {
+		// Set a bunch of inline CSS styles
+		style: function (val) {
+			$.extend(this.style, val);
+		},
+
+		// Set a bunch of attributes
+		attributes: function (o) {
+			for (var attribute in o) {
+				this.setAttribute(attribute, o[attribute]);
+			}
+		},
+
+		// Set a bunch of properties on the element
+		properties: function (val) {
+			$.extend(this, val);
+		},
+
+		// Bind one or more events to the element
+		events: function (val) {
+			if (val instanceof EventTarget) {
+				// Copy events from other element (requires Bliss Full)
+				var me = this;
+
+				// Copy listeners
+				if (val[_] && val[_].bliss) {
+					var listeners = val[_].bliss.listeners;
+
+					for (var type in listeners) {
+						listeners[type].forEach(function(l){
+							me.addEventListener(type, l.callback, l.capture);
+						});
+					}
+				}
+
+				// Copy inline events
+				for (var onevent in val) {
+					if (onevent.indexOf("on") === 0) {
+						this[onevent] = val[onevent];
+					}
+				}
+			}
+			else {
+				for (var events in val) {
+					events.split(/\s+/).forEach(function (event) {
+						this.addEventListener(event, val[events]);
+					}, this);
+				}
+			}
+		},
+
+		once: function(val) {
+			if (arguments.length == 2) {
+				val = {};
+				val[arguments[0]] = arguments[1];
+			}
+
+			for (var events in val) {
+				events.split(/\s+/).forEach(function (event) {
+					var me = this;
+					this.addEventListener(event, function callback() {
+						me.removeEventListener(event, callback);
+						return val[events].apply(this, arguments);
+					});
+				}, this);
+			}
+		},
+
+		// Event delegation
+		delegate: function(val) {
+			if (arguments.length === 3) {
+				// Called with ("type", "selector", callback)
+				val = {};
+				val[arguments[0]] = {};
+				val[arguments[0]][arguments[1]] = arguments[2];
+			}
+			else if (arguments.length === 2) {
+				// Called with ("type", selectors & callbacks)
+				val = {};
+				val[arguments[0]] = arguments[1];
+			}
+
+			var element = this;
+
+			for (var type in val) {
+				(function (type, callbacks) {
+					element.addEventListener(type, function(evt) {
+						for (var selector in callbacks) {
+							if (evt.target.matches(selector)) { // Do ancestors count?
+								callbacks[selector].call(this, evt);
+							}
+						}
+					});
+				})(type, val[type]);
+			}
+		},
+
+		// Set the contents as a string, an element, an object to create an element or an array of these
+		contents: function (val) {
+			if (val || val === 0) {
+				(Array.isArray(val)? val : [val]).forEach(function (child) {
+					if (/^(string|number|object)$/.test($.type(child))) {
+						child = $.create(child);
+					}
+
+					if (child instanceof Node) {
+						this.appendChild(child);
+					}
+				}, this);
+			}
+		},
+
+		// Append the element inside another element
+		inside: function (element) {
+			element.appendChild(this);
+		},
+
+		// Insert the element before another element
+		before: function (element) {
+			element.parentNode.insertBefore(this, element);
+		},
+
+		// Insert the element after another element
+		after: function (element) {
+			element.parentNode.insertBefore(this, element.nextSibling);
+		},
+
+		// Insert the element before another element's contents
+		start: function (element) {
+			element.insertBefore(this, element.firstChild);
+		},
+
+		// Wrap the element around another element
+		around: function (element) {
+			if (element.parentNode) {
+				$.before(this, element);
+			}
+
+			(/^template$/i.test(this.nodeName)? this.content || this : this).appendChild(element);
+		}
+	};
+
+	$.Array = function (subject) {
+		this.subject = subject;
+	};
+
+	$.Array.prototype = {
+		all: function(method) {
+			var args = $$(arguments).slice(1);
+
+			return this[method].apply(this, args);
+		}
+	};
+
+	// Extends Bliss with more methods
+	$.add = function (methods, on, noOverwrite) {
+		on = $.extend({$: true, element: true, array: true}, on);
+
+		if ($.type(arguments[0]) === "string") {
+			methods = {};
+			methods[arguments[0]] = arguments[1];
+		}
+
+		for (var method in methods) {
+
+			try {
+				var callback = methods[method];
+			}
+			catch (e) {
+				continue;
+			}
+
+			(function(method, callback){
+
+				if ($.type(callback) == "function") {
+					if (on.element && (!(method in $.Element.prototype) || !noOverwrite)) {
+						$.Element.prototype[method] = function () {
+							return this.subject && $.defined(callback.apply(this.subject, arguments), this.subject);
+						};
+					}
+
+					if (on.array && (!(method in $.Array.prototype) || !noOverwrite)) {
+						$.Array.prototype[method] = function() {
+							var args = arguments;
+							return this.subject.map(function(element) {
+								return element && $.defined(callback.apply(element, args), element);
+							});
+						};
+					}
+
+					if (on.$) {
+						$.sources[method] = $[method] = callback;
+
+						if (on.array || on.element) {
+							$[method] = function () {
+								var args = [].slice.apply(arguments);
+								var subject = args.shift();
+								var Type = on.array && Array.isArray(subject)? "Array" : "Element";
+
+								return $[Type].prototype[method].apply({subject: subject}, args);
+							}
+						}
+					}
+				}
+
+			})(method, callback);
+		}
+	};
+
+	$.add($.Array.prototype, {element: false});
+	$.add($.Element.prototype);
+	$.add($.setProps);
+	$.add($.classProps, {element: false, array: false});
+	$.add(HTMLElement.prototype, null, true);
 
 })();
+
 (function($) {
 "use strict";
 

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -1,605 +1,609 @@
 (function() {
-"use strict";
 
-// Copy properties from one object to another. Overwrites allowed.
-function extend(to, from, whitelist) {
-	for (var property in from) {
-		if (whitelist) {
-			var type = $.type(whitelist);
+	"use strict";
 
-			if (whitelist === "own" && !from.hasOwnProperty(property) ||
-				type === "array" && whitelist.indexOf(property) === -1 ||
-				type === "regexp" && !whitelist.test(property) ||
-				type === "function" && !whitelist.call(from, property)) {
-				continue;
+	// Copy properties from one object to another. Overwrites allowed.
+	function extend(to, from, whitelist) {
+		for (var property in from) {
+			if (whitelist) {
+				var type = $.type(whitelist);
+
+				if (whitelist === "own" && !from.hasOwnProperty(property) ||
+					type === "array" && whitelist.indexOf(property) === -1 ||
+					type === "regexp" && !whitelist.test(property) ||
+					type === "function" && !whitelist.call(from, property)) {
+					continue;
+				}
 			}
-		}
 
-		// To copy gettters/setters, preserve flags etc
-		var descriptor = Object.getOwnPropertyDescriptor(from, property);
+			// To copy gettters/setters, preserve flags etc
+			var descriptor = Object.getOwnPropertyDescriptor(from, property);
 
-		if (descriptor && (!descriptor.writable || !descriptor.configurable || !descriptor.enumerable || descriptor.get || descriptor.set)) {
-			delete to[property];
-			Object.defineProperty(to, property, descriptor);
-		}
-		else {
-			to[property] = from[property];
-		}
-	}
-	
-	return to;
-};
-
-var $ = self.Bliss = extend(function(expr, context) {
-	return $.type(expr) === "string"? (context || document).querySelector(expr) : expr || null;
-}, self.Bliss);
-
-extend($, {
-	extend: extend,
-
-	property: $.property || "_",
-
-	sources: {},
-
-	$: function(expr, context) {
-		return expr instanceof Node || expr instanceof Window? [expr] :
-		       [].slice.call(typeof expr == "string"? (context || document).querySelectorAll(expr) : expr || []);
-	},
-	
-	/**
-	 * Returns the [[Class]] of an object in lowercase (eg. array, date, regexp, string etc)
-	 */
-	type: function(obj) {
-		if (obj === null) { return 'null'; }
-	
-		if (obj === undefined) { return 'undefined'; }
-	
-		var ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
-	
-		if(ret == 'number' && isNaN(obj)) {
-			return 'nan';
-		}
-	
-		return ret;
-	},
-	
-	/*
-	 * Return first non-undefined value. Mainly used internally.
-	 */
-	defined: function () {
-		for (var i=0; i<arguments.length; i++) {
-			if (arguments[i] !== undefined) {
-				return arguments[i];
-			}
-		}
-	},
-	
-	create: function (tag, o) {
-		if (arguments.length === 1) {
-			if ($.type(tag) === "string") {
-				return document.createTextNode(tag);
-			}
-			
-			o = tag;
-			tag = o.tag;			
-		}
-
-		delete o.tag;
-		
-		return $.set(document.createElement(tag || "div"), o);
-	},
-
-	ready: function(context) {
-		context = context || document;
-
-		return new Promise(function(resolve, reject){
-			if (context.readyState !== "loading") {
-				resolve();
+			if (descriptor && (!descriptor.writable || !descriptor.configurable || !descriptor.enumerable || descriptor.get || descriptor.set)) {
+				delete to[property];
+				Object.defineProperty(to, property, descriptor);
 			}
 			else {
-				context.addEventListener("DOMContentLoaded", function(){
-					resolve();
-				});
-			}
-		});
-	},
-
-	// Helper for defining OOP-like “classes”
-	Class: function(o) {
-		var init = o.constructor || function(){};
-		delete o.constructor;
-
-		var abstract = o.abstract;
-		delete o.abstract;
-
-		var ret = function() {
-			if (abstract && this.constructor === ret) {
-				throw new Error("Abstract classes cannot be directly instantiated.");
-			}
-
-			if (this.constructor.super && this.constructor.super != ret) {
-				// FIXME This should never happen, but for some reason it does if ret.super is null
-				// Debugging revealed that somehow this.constructor !== ret, wtf. Must look more into this
-				this.constructor.super.apply(this, arguments);
-			}
-
-			return init.apply(this, arguments);
-		};
-
-		ret.super = o.extends || null;
-		delete o.extends;
-
-		ret.prototype = $.extend(Object.create(ret.super && ret.super.prototype), {
-			constructor: ret
-		});
-
-		$.extend(ret, o.static);
-		delete o.static;
-
-		for (var property in o) {
-			if (property in $.classProps) {
-				$.classProps[property].call(ret, ret.prototype, o[property]);
-				delete o[property];
+				to[property] = from[property];
 			}
 		}
 
-		// Anything that remains is an instance method/property or ret.prototype.constructor
-		$.extend(ret.prototype, o);
+		return to;
+	};
 
-		// For easier calling of super methods
-		// This doesn't save us from having to use .call(this) though
-		ret.prototype.super = ret.super? ret.super.prototype : null;
-		
-		return ret;
-	},
+	var $ = self.Bliss = extend(function(expr, context) {
+		return $.type(expr) === "string"? (context || document).querySelector(expr) : expr || null;
+	}, self.Bliss);
 
-	// Properties with special handling in classes
-	classProps: {
-		// Lazily evaluated properties
-		lazy: function(obj, property, getter) {
-			if (arguments.length >= 3) {
-				Object.defineProperty(obj, property, {
-					get: function() {
-						// FIXME this does not work for instances if property is defined on the prototype
-						delete this[property];
+	extend($, {
+		extend: extend,
 
-						try { this[property] = 5;
-						} catch(e) {console.error(e)}
+		property: $.property || "_",
 
-						return this[property] = getter.call(this);
-					},
-					configurable: true,
-					enumerable: true
-				});
-			}
-			else if (arguments.length === 2) {
-				for (var prop in property) {
-					$.lazy(obj, prop, property[prop]);
-				}
-			}
+		sources: {},
 
-			return obj;
+		$: function(expr, context) {
+			return expr instanceof Node || expr instanceof Window? [expr] :
+						[].slice.call(typeof expr == "string"? (context || document).querySelectorAll(expr) : expr || []);
 		},
 
-		// Properties that behave like normal properties but also execute code upon getting/setting
-		live: function(obj, property, descriptor) {
-			if (arguments.length >= 3) {
-				Object.defineProperty(obj, property, {
-					get: function() {
-						var value = this["_" + property];
-						var ret = descriptor.get && descriptor.get.call(this, value);
-						return ret !== undefined? ret : value;
-					},
-					set: function(v) {
-						var value = this["_" + property];
-						var ret = descriptor.set && descriptor.set.call(this, v, value);
-						this["_" + property] = ret !== undefined? ret : v;
-					},
-					configurable: descriptor.configurable,
-					enumerable: descriptor.enumerable
-				});
-			}
-			else if (arguments.length === 2) {
-				for (var prop in property) {
-					$.live(obj, prop, property[prop]);
-				}
+		/**
+		* Returns the [[Class]] of an object in lowercase (eg. array, date, regexp, string etc)
+		*/
+		type: function(obj) {
+			if (obj === null) { return "null"; }
+
+			if (obj === undefined) { return "undefined"; }
+
+			var ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
+
+			if(ret == "number" && isNaN(obj)) {
+				return "nan";
 			}
 
-			return obj;
+			return ret;
 		},
-	},
 
-	// Includes a script, returns a promise
-	include: function() {
-		var url = arguments[arguments.length - 1];
-		var loaded = arguments.length === 2? arguments[0] : false;
-
-		var script = document.createElement("script");
-
-		return loaded? Promise.resolve() : new Promise(function(resolve, reject){
-			$.set(script, {
-				async: true,
-				onload: function() {
-					resolve();
-					$.remove(script);
-				},
-				onerror: function() {
-					reject();
-				},
-				src: url,
-				inside: document.head
-			});
-		});
-		
-	},
-
-	/*
-	 * Fetch API inspired XHR wrapper. Returns promise.
-	 */
-	fetch: function(url, o) {
-		if (!url) {
-			throw new TypeError("URL parameter is mandatory and cannot be " + url);
-		}
-
-		// Set defaults & fixup arguments
-		url = new URL(url, location);
-		o = o || {};
-		o.data = o.data || '';
-		o.method = o.method || 'GET';
-		o.headers = o.headers || {};
-
-		var xhr = new XMLHttpRequest();
-
-		if ($.type(o.data) !== "string") {
-			o.data = Object.keys(o.data).map(function(key){ return key + "=" + encodeURIComponent(o.data[key])}).join("&");
-		}
-
-		if (o.method === "GET" && o.data) {
-			url.search += o.data;
-		}
-		
-		document.body.setAttribute('data-loading', url);
-		
-		xhr.open(o.method, url, !o.sync);
-
-		for (var property in o) {
-			if (property in xhr) {
-				try {
-					xhr[property] = o[property];
-				}
-				catch (e) {
-					self.console && console.error(e);
+		/*
+		* Return first non-undefined value. Mainly used internally.
+		*/
+		defined: function () {
+			for (var i=0; i<arguments.length; i++) {
+				if (arguments[i] !== undefined) {
+					return arguments[i];
 				}
 			}
-		}
-		
-		if (o.method !== 'GET' && !o.headers['Content-type'] && !o.headers['Content-Type']) {
-			xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-		}
-		
-		for (var header in o.headers) {
-			xhr.setRequestHeader(header, o.headers[header]);
-		}
-		
-		return new Promise(function(resolve, reject){
-			xhr.onload = function(){
-				document.body.removeAttribute('data-loading');
-					
-				if (xhr.status === 0 || xhr.status >= 200 && xhr.status < 300 || xhr.status === 304) {
-					// Success!
-					resolve(xhr);
+		},
+
+		create: function (tag, o) {
+			if (arguments.length === 1) {
+				if ($.type(tag) === "string") {
+					return document.createTextNode(tag);
+				}
+
+				o = tag;
+				tag = o.tag;
+			}
+
+			delete o.tag;
+
+			return $.set(document.createElement(tag || "div"), o);
+		},
+
+		ready: function(context) {
+			context = context || document;
+
+			return new Promise(function(resolve, reject){
+				if (context.readyState !== "loading") {
+					resolve();
 				}
 				else {
-					reject(Error(xhr.statusText));
-				}
-			
-			};
-			
-			xhr.onerror = function() {
-				document.body.removeAttribute('data-loading');
-				reject(Error("Network Error"));
-			};
-
-			xhr.send(o.method === 'GET'? null : o.data);
-		});
-	}
-});
-
-var _ = $.property;
-
-$.Element = function (subject) {
-	this.subject = subject;
-
-	// Author-defined element-related data
-	this.data = {};
-
-	// Internal Bliss element-related data
-	this.bliss = {};
-};
-
-$.Element.prototype = {
-	set: function (properties) {
-		if ($.type(arguments[0]) === "string") {
-			properties = {};
-			properties[arguments[0]] = arguments[1];
-		}
-
-		for (var property in properties) {
-			if (property in $.setProps) {
-				$.setProps[property].call(this, properties[property]);
-			}
-			else if (property in this) {
-				this[property] = properties[property];
-			}
-			else {
-				if (!this.setAttribute) {
-					console.log(this);
-				}
-				this.setAttribute(property, properties[property]);
-			}
-		}
-	},
-
-	// Run a CSS transition, return promise
-	transition: function(props, duration) {
-		duration = +duration || 400;
-
-		return new Promise(function(resolve, reject){
-			if ("transition" in this.style) {
-				// Get existing style
-				var previous = $.extend({}, this.style, /^transition(Duration|Property)$/);
-
-				$.style(this, {
-					transitionDuration: (duration || 400) + "ms",
-					transitionProperty: Object.keys(props).join(", ")
-				});
-
-				$.once(this, "transitionend", function(){
-					clearTimeout(i);
-					$.style(this, previous);
-					resolve(this);
-				});
-
-				// Failsafe, in case transitionend doesn’t fire
-				var i = setTimeout(resolve, duration+50, this);
-
-				$.style(this, props);
-			}
-			else {
-				$.style(this, props);
-				resolve(this);
-			}
-		}.bind(this));
-	},
-	
-	// Fire a synthesized event on the element
-	fire: function (type, properties) {
-		var evt = document.createEvent("HTMLEvents");
-				
-		evt.initEvent(type, true, true );
-
-		this.dispatchEvent($.extend(evt, properties));
-	}
-};
-
-/*
- * Properties with custom handling in $.set()
- * Also available as functions directly on element._ and on $
- */
-$.setProps = {
-	// Set a bunch of inline CSS styles
-	style: function (val) {
-		$.extend(this.style, val);
-	},
-	
-	// Set a bunch of attributes
-	attributes: function (o) {
-		for (var attribute in o) {
-			this.setAttribute(attribute, o[attribute]);
-		}
-	},
-	
-	// Set a bunch of properties on the element
-	properties: function (val) {
-		$.extend(this, val);
-	},
-	
-	// Bind one or more events to the element
-	events: function (val) {
-		if (val instanceof EventTarget) {
-			// Copy events from other element (requires Bliss Full)
-			var me = this;
-
-			// Copy listeners
-			if (val[_] && val[_].bliss) {
-				var listeners = val[_].bliss.listeners;
-
-				for (var type in listeners) {
-					listeners[type].forEach(function(l){
-						me.addEventListener(type, l.callback, l.capture);
+					context.addEventListener("DOMContentLoaded", function(){
+						resolve();
 					});
 				}
-			}
+			});
+		},
 
-			// Copy inline events
-			for (var onevent in val) {
-				if (onevent.indexOf("on") === 0) {
-					this[onevent] = val[onevent];
+		// Helper for defining OOP-like “classes”
+		Class: function(o) {
+			var init = o.constructor || function(){};
+			delete o.constructor;
+
+			var abstract = o.abstract;
+			delete o.abstract;
+
+			var ret = function() {
+				if (abstract && this.constructor === ret) {
+					throw new Error("Abstract classes cannot be directly instantiated.");
+				}
+
+				if (this.constructor.super && this.constructor.super != ret) {
+					// FIXME This should never happen, but for some reason it does if ret.super is null
+					// Debugging revealed that somehow this.constructor !== ret, wtf. Must look more into this
+					this.constructor.super.apply(this, arguments);
+				}
+
+				return init.apply(this, arguments);
+			};
+
+			ret.super = o.extends || null;
+			delete o.extends;
+
+			ret.prototype = $.extend(Object.create(ret.super && ret.super.prototype), {
+				constructor: ret
+			});
+
+			$.extend(ret, o.static);
+			delete o.static;
+
+			for (var property in o) {
+				if (property in $.classProps) {
+					$.classProps[property].call(ret, ret.prototype, o[property]);
+					delete o[property];
 				}
 			}
-		}
-		else {
-			for (var events in val) {
-				events.split(/\s+/).forEach(function (event) {
-					this.addEventListener(event, val[events]);
-				}, this);
-			}
-		}
-	},
 
-	once: function(val) {
-		if (arguments.length == 2) {
-			val = {};
-			val[arguments[0]] = arguments[1];
-		}
+			// Anything that remains is an instance method/property or ret.prototype.constructor
+			$.extend(ret.prototype, o);
 
-		for (var events in val) {
-			events.split(/\s+/).forEach(function (event) {
-				var me = this;
-				this.addEventListener(event, function callback() {
-					me.removeEventListener(event, callback);
-					return val[events].apply(this, arguments);
-				});
-			}, this);
-		}
-	},
+			// For easier calling of super methods
+			// This doesn't save us from having to use .call(this) though
+			ret.prototype.super = ret.super? ret.super.prototype : null;
 
-	// Event delegation
-	delegate: function(val) {
-		if (arguments.length === 3) {
-			// Called with ("type", "selector", callback)
-			val = {};
-			val[arguments[0]] = {};
-			val[arguments[0]][arguments[1]] = arguments[2];
-		}
-		else if (arguments.length === 2) {
-			// Called with ("type", selectors & callbacks)
-			val = {};
-			val[arguments[0]] = arguments[1];
-		}
+			return ret;
+		},
 
-		var element = this;
+		// Properties with special handling in classes
+		classProps: {
+			// Lazily evaluated properties
+			lazy: function(obj, property, getter) {
+				if (arguments.length >= 3) {
+					Object.defineProperty(obj, property, {
+						get: function() {
+							// FIXME this does not work for instances if property is defined on the prototype
+							delete this[property];
 
-		for (var type in val) {
-			(function (type, callbacks) {
-				element.addEventListener(type, function(evt) {
-					for (var selector in callbacks) {
-						if (evt.target.matches(selector)) { // Do ancestors count?
-							callbacks[selector].call(this, evt);
-						}
-					}	
-				});
-			})(type, val[type]);
-		}
-	},
-	
-	// Set the contents as a string, an element, an object to create an element or an array of these
-	contents: function (val) {
-		if (val || val === 0) {
-			(Array.isArray(val)? val : [val]).forEach(function (child) {
-				if (/^(string|number|object)$/.test($.type(child))) {
-					child = $.create(child);
-				}
-				
-				if (child instanceof Node) {
-					this.appendChild(child);
-				}
-			}, this);
-		}
-	},
-	
-	// Append the element inside another element
-	inside: function (element) {
-		element.appendChild(this);
-	},
-	
-	// Insert the element before another element
-	before: function (element) {
-		element.parentNode.insertBefore(this, element);
-	},
-	
-	// Insert the element after another element
-	after: function (element) {
-		element.parentNode.insertBefore(this, element.nextSibling);
-	},
-	
-	// Insert the element before another element's contents
-	start: function (element) {
-		element.insertBefore(this, element.firstChild);
-	},
-	
-	// Wrap the element around another element
-	around: function (element) {
-		if (element.parentNode) {
-			$.before(this, element);
-		}
-		
-		(/^template$/i.test(this.nodeName)? this.content || this : this).appendChild(element);
-	}
-};
+							try {
+								this[property] = 5;
+							}
+							catch(e) {
+								console.error(e)
+							}
 
-$.Array = function (subject) {
-	this.subject = subject;
-};
-
-$.Array.prototype = {
-	all: function(method) {
-		var args = $$(arguments).slice(1);
-
-		return this[method].apply(this, args);
-	}
-};
-
-// Extends Bliss with more methods
-$.add = function (methods, on, noOverwrite) {
-	on = $.extend({$: true, element: true, array: true}, on);
-	
-	if ($.type(arguments[0]) === "string") {
-		methods = {};
-		methods[arguments[0]] = arguments[1];
-	}
-	
-	for (var method in methods) {
-
-		try {
-			var callback = methods[method];
-		}
-		catch (e) {
-			continue;
-		}
-		
-		(function(method, callback){
-
-		
-		if ($.type(callback) == "function") {
-			if (on.element && (!(method in $.Element.prototype) || !noOverwrite)) {
-				$.Element.prototype[method] = function () {
-					return this.subject && $.defined(callback.apply(this.subject, arguments), this.subject);
-				};
-			}
-
-			if (on.array && (!(method in $.Array.prototype) || !noOverwrite)) {
-				$.Array.prototype[method] = function() {
-					var args = arguments;
-					return this.subject.map(function(element) {
-						return element && $.defined(callback.apply(element, args), element);
+							return this[property] = getter.call(this);
+						},
+						configurable: true,
+						enumerable: true
 					});
-				};
+				}
+				else if (arguments.length === 2) {
+					for (var prop in property) {
+						$.lazy(obj, prop, property[prop]);
+					}
+				}
+
+				return obj;
+			},
+
+			// Properties that behave like normal properties but also execute code upon getting/setting
+			live: function(obj, property, descriptor) {
+				if (arguments.length >= 3) {
+					Object.defineProperty(obj, property, {
+						get: function() {
+							var value = this["_" + property];
+							var ret = descriptor.get && descriptor.get.call(this, value);
+							return ret !== undefined? ret : value;
+						},
+						set: function(v) {
+							var value = this["_" + property];
+							var ret = descriptor.set && descriptor.set.call(this, v, value);
+							this["_" + property] = ret !== undefined? ret : v;
+						},
+						configurable: descriptor.configurable,
+						enumerable: descriptor.enumerable
+					});
+				}
+				else if (arguments.length === 2) {
+					for (var prop in property) {
+						$.live(obj, prop, property[prop]);
+					}
+				}
+
+				return obj;
+			}
+		},
+
+		// Includes a script, returns a promise
+		include: function() {
+			var url = arguments[arguments.length - 1];
+			var loaded = arguments.length === 2? arguments[0] : false;
+
+			var script = document.createElement("script");
+
+			return loaded? Promise.resolve() : new Promise(function(resolve, reject){
+				$.set(script, {
+					async: true,
+					onload: function() {
+						resolve();
+						$.remove(script);
+					},
+					onerror: function() {
+						reject();
+					},
+					src: url,
+					inside: document.head
+				});
+			});
+
+		},
+
+		/*
+		* Fetch API inspired XHR wrapper. Returns promise.
+		*/
+		fetch: function(url, o) {
+			if (!url) {
+				throw new TypeError("URL parameter is mandatory and cannot be " + url);
 			}
 
-			if (on.$) {
-				$.sources[method] = $[method] = callback;
+			// Set defaults & fixup arguments
+			url = new URL(url, location);
+			o = o || {};
+			o.data = o.data || "";
+			o.method = o.method || "GET";
+			o.headers = o.headers || {};
 
-				if (on.array || on.element) {
-					$[method] = function () {
-						var args = [].slice.apply(arguments);
-						var subject = args.shift();
-						var Type = on.array && Array.isArray(subject)? "Array" : "Element";
+			var xhr = new XMLHttpRequest();
 
-						return $[Type].prototype[method].apply({subject: subject}, args);
+			if ($.type(o.data) !== "string") {
+				o.data = Object.keys(o.data).map(function(key){ return key + "=" + encodeURIComponent(o.data[key])}).join("&");
+			}
+
+			if (o.method === "GET" && o.data) {
+				url.search += o.data;
+			}
+
+			document.body.setAttribute("data-loading", url);
+
+			xhr.open(o.method, url, !o.sync);
+
+			for (var property in o) {
+				if (property in xhr) {
+					try {
+						xhr[property] = o[property];
+					}
+					catch (e) {
+						self.console && console.error(e);
 					}
 				}
 			}
-		}
-		
-		})(method, callback);
-	}
-};
 
-$.add($.Array.prototype, {element: false});
-$.add($.Element.prototype);
-$.add($.setProps);
-$.add($.classProps, {element: false, array: false});
-$.add(HTMLElement.prototype, null, true);
+			if (o.method !== "GET" && !o.headers["Content-type"] && !o.headers["Content-Type"]) {
+				xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+			}
+
+			for (var header in o.headers) {
+				xhr.setRequestHeader(header, o.headers[header]);
+			}
+
+			return new Promise(function(resolve, reject){
+				xhr.onload = function(){
+					document.body.removeAttribute("data-loading");
+
+					if (xhr.status === 0 || xhr.status >= 200 && xhr.status < 300 || xhr.status === 304) {
+						// Success!
+						resolve(xhr);
+					}
+					else {
+						reject(Error(xhr.statusText));
+					}
+
+				};
+
+				xhr.onerror = function() {
+					document.body.removeAttribute("data-loading");
+					reject(Error("Network Error"));
+				};
+
+				xhr.send(o.method === "GET"? null : o.data);
+			});
+		}
+	});
+
+	var _ = $.property;
+
+	$.Element = function (subject) {
+		this.subject = subject;
+
+		// Author-defined element-related data
+		this.data = {};
+
+		// Internal Bliss element-related data
+		this.bliss = {};
+	};
+
+	$.Element.prototype = {
+		set: function (properties) {
+			if ($.type(arguments[0]) === "string") {
+				properties = {};
+				properties[arguments[0]] = arguments[1];
+			}
+
+			for (var property in properties) {
+				if (property in $.setProps) {
+					$.setProps[property].call(this, properties[property]);
+				}
+				else if (property in this) {
+					this[property] = properties[property];
+				}
+				else {
+					if (!this.setAttribute) {
+						console.log(this);
+					}
+					this.setAttribute(property, properties[property]);
+				}
+			}
+		},
+
+		// Run a CSS transition, return promise
+		transition: function(props, duration) {
+			duration = +duration || 400;
+
+			return new Promise(function(resolve, reject){
+				if ("transition" in this.style) {
+					// Get existing style
+					var previous = $.extend({}, this.style, /^transition(Duration|Property)$/);
+
+					$.style(this, {
+						transitionDuration: (duration || 400) + "ms",
+						transitionProperty: Object.keys(props).join(", ")
+					});
+
+					$.once(this, "transitionend", function(){
+						clearTimeout(i);
+						$.style(this, previous);
+						resolve(this);
+					});
+
+					// Failsafe, in case transitionend doesn’t fire
+					var i = setTimeout(resolve, duration+50, this);
+
+					$.style(this, props);
+				}
+				else {
+					$.style(this, props);
+					resolve(this);
+				}
+			}.bind(this));
+		},
+
+		// Fire a synthesized event on the element
+		fire: function (type, properties) {
+			var evt = document.createEvent("HTMLEvents");
+
+			evt.initEvent(type, true, true );
+
+			this.dispatchEvent($.extend(evt, properties));
+		}
+	};
+
+	/*
+	* Properties with custom handling in $.set()
+	* Also available as functions directly on element._ and on $
+	*/
+	$.setProps = {
+		// Set a bunch of inline CSS styles
+		style: function (val) {
+			$.extend(this.style, val);
+		},
+
+		// Set a bunch of attributes
+		attributes: function (o) {
+			for (var attribute in o) {
+				this.setAttribute(attribute, o[attribute]);
+			}
+		},
+
+		// Set a bunch of properties on the element
+		properties: function (val) {
+			$.extend(this, val);
+		},
+
+		// Bind one or more events to the element
+		events: function (val) {
+			if (val instanceof EventTarget) {
+				// Copy events from other element (requires Bliss Full)
+				var me = this;
+
+				// Copy listeners
+				if (val[_] && val[_].bliss) {
+					var listeners = val[_].bliss.listeners;
+
+					for (var type in listeners) {
+						listeners[type].forEach(function(l){
+							me.addEventListener(type, l.callback, l.capture);
+						});
+					}
+				}
+
+				// Copy inline events
+				for (var onevent in val) {
+					if (onevent.indexOf("on") === 0) {
+						this[onevent] = val[onevent];
+					}
+				}
+			}
+			else {
+				for (var events in val) {
+					events.split(/\s+/).forEach(function (event) {
+						this.addEventListener(event, val[events]);
+					}, this);
+				}
+			}
+		},
+
+		once: function(val) {
+			if (arguments.length == 2) {
+				val = {};
+				val[arguments[0]] = arguments[1];
+			}
+
+			for (var events in val) {
+				events.split(/\s+/).forEach(function (event) {
+					var me = this;
+					this.addEventListener(event, function callback() {
+						me.removeEventListener(event, callback);
+						return val[events].apply(this, arguments);
+					});
+				}, this);
+			}
+		},
+
+		// Event delegation
+		delegate: function(val) {
+			if (arguments.length === 3) {
+				// Called with ("type", "selector", callback)
+				val = {};
+				val[arguments[0]] = {};
+				val[arguments[0]][arguments[1]] = arguments[2];
+			}
+			else if (arguments.length === 2) {
+				// Called with ("type", selectors & callbacks)
+				val = {};
+				val[arguments[0]] = arguments[1];
+			}
+
+			var element = this;
+
+			for (var type in val) {
+				(function (type, callbacks) {
+					element.addEventListener(type, function(evt) {
+						for (var selector in callbacks) {
+							if (evt.target.matches(selector)) { // Do ancestors count?
+								callbacks[selector].call(this, evt);
+							}
+						}
+					});
+				})(type, val[type]);
+			}
+		},
+
+		// Set the contents as a string, an element, an object to create an element or an array of these
+		contents: function (val) {
+			if (val || val === 0) {
+				(Array.isArray(val)? val : [val]).forEach(function (child) {
+					if (/^(string|number|object)$/.test($.type(child))) {
+						child = $.create(child);
+					}
+
+					if (child instanceof Node) {
+						this.appendChild(child);
+					}
+				}, this);
+			}
+		},
+
+		// Append the element inside another element
+		inside: function (element) {
+			element.appendChild(this);
+		},
+
+		// Insert the element before another element
+		before: function (element) {
+			element.parentNode.insertBefore(this, element);
+		},
+
+		// Insert the element after another element
+		after: function (element) {
+			element.parentNode.insertBefore(this, element.nextSibling);
+		},
+
+		// Insert the element before another element's contents
+		start: function (element) {
+			element.insertBefore(this, element.firstChild);
+		},
+
+		// Wrap the element around another element
+		around: function (element) {
+			if (element.parentNode) {
+				$.before(this, element);
+			}
+
+			(/^template$/i.test(this.nodeName)? this.content || this : this).appendChild(element);
+		}
+	};
+
+	$.Array = function (subject) {
+		this.subject = subject;
+	};
+
+	$.Array.prototype = {
+		all: function(method) {
+			var args = $$(arguments).slice(1);
+
+			return this[method].apply(this, args);
+		}
+	};
+
+	// Extends Bliss with more methods
+	$.add = function (methods, on, noOverwrite) {
+		on = $.extend({$: true, element: true, array: true}, on);
+
+		if ($.type(arguments[0]) === "string") {
+			methods = {};
+			methods[arguments[0]] = arguments[1];
+		}
+
+		for (var method in methods) {
+
+			try {
+				var callback = methods[method];
+			}
+			catch (e) {
+				continue;
+			}
+
+			(function(method, callback){
+
+				if ($.type(callback) == "function") {
+					if (on.element && (!(method in $.Element.prototype) || !noOverwrite)) {
+						$.Element.prototype[method] = function () {
+							return this.subject && $.defined(callback.apply(this.subject, arguments), this.subject);
+						};
+					}
+
+					if (on.array && (!(method in $.Array.prototype) || !noOverwrite)) {
+						$.Array.prototype[method] = function() {
+							var args = arguments;
+							return this.subject.map(function(element) {
+								return element && $.defined(callback.apply(element, args), element);
+							});
+						};
+					}
+
+					if (on.$) {
+						$.sources[method] = $[method] = callback;
+
+						if (on.array || on.element) {
+							$[method] = function () {
+								var args = [].slice.apply(arguments);
+								var subject = args.shift();
+								var Type = on.array && Array.isArray(subject)? "Array" : "Element";
+
+								return $[Type].prototype[method].apply({subject: subject}, args);
+							}
+						}
+					}
+				}
+
+			})(method, callback);
+		}
+	};
+
+	$.add($.Array.prototype, {element: false});
+	$.add($.Element.prototype);
+	$.add($.setProps);
+	$.add($.classProps, {element: false, array: false});
+	$.add(HTMLElement.prototype, null, true);
 
 })();

--- a/docs.html
+++ b/docs.html
@@ -106,7 +106,7 @@
 </section>
 
 <section id="vanilla">
-	<h1>Vanilla methods</h1>
+	<h1>Vanilla Methods</h1>
 
 	<p>You don’t need Bliss or any library for any of these. All the following are 100% pure Vanilla JS! Click on the code for documentation and browser support info.</p>
 
@@ -175,6 +175,11 @@
 			<!-- tr>td+td>a[href]>pre>code -->
 		</tbody>
 	</table>
+
+	<p>Note that all vanilla <strong>methods</strong> from elements (specifically, from <code>HTMLElement</code>) are also available on <code>$</code> as well as the <code>_</code> property for both elements and arrays, so for example, to remove all divs on a page, you could write either of the following:</p>
+	<pre><code>$$("div")._.remove();</code></pre>
+	<pre><code>$.remove($$("div"));</code></pre>
+
 </section>
 
 <section>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,32 +1,39 @@
 // grab our gulp packages
-var gulp  = require('gulp');
-var gutil = require('gulp-util');
-var uglify = require('gulp-uglify');
-var rename = require('gulp-rename')
-var concat = require('gulp-concat');
+var gulp  = require("gulp");
+var gutil = require("gulp-util");
+var uglify = require("gulp-uglify");
+var rename = require("gulp-rename")
+var concat = require("gulp-concat");
+var eslint = require("gulp-eslint");
 
-gulp.task('concat', function() {
-  return gulp.src(['bliss.shy.js', 'bliss._.js'])
-	.pipe(concat('bliss.js'))
-	.pipe(gulp.dest('.'));
+gulp.task("concat", function() {
+  return gulp.src(["bliss.shy.js", "bliss._.js"])
+	.pipe(concat("bliss.js"))
+	.pipe(gulp.dest("."));
 });
 
-gulp.task('minify', ['concat'], function() {
+gulp.task("minify", ["concat"], function() {
 	var u = uglify();
-	u.on('error', function(error){
+	u.on("error", function(error){
 		console.error(error);
 		u.end();
 	});
 
-	return gulp.src(['bliss.shy.js', 'bliss.js'])
+	return gulp.src(["bliss.shy.js", "bliss.js"])
 	.pipe(u)
-	.pipe(rename({ suffix: '.min' }))
-	.pipe(gulp.dest('.'))
-	
+	.pipe(rename({ suffix: ".min" }))
+	.pipe(gulp.dest("."))
 });
 
-gulp.task('watch', function() {
-	gulp.watch(["*.js"], ['concat', 'minify']);
+gulp.task("lint", function() {
+	return gulp.src(["bliss.shy.js", "bliss.js"])
+		.pipe(eslint())
+		.pipe(eslint.format())
+		.pipe(eslint.failAfterError());
 });
 
-gulp.task('default', ['concat', 'minify']);
+gulp.task("watch", function() {
+	gulp.watch(["*.js"], ["lint", "concat", "minify"]);
+});
+
+gulp.task("default", ["lint", "concat", "minify"]);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai": "^3.4.1",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
+    "gulp-eslint": "^1.1.1",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.7",

--- a/style/docs.css
+++ b/style/docs.css
@@ -100,7 +100,7 @@
 	color: inherit;
 }
 
-#vanilla pre {
+#vanilla table pre {
 	box-shadow: none;
 	padding: .6em 1em;
 	border-radius: .3em;


### PR DESCRIPTION
Docs ask contributors to following existing code style, but nothing is enforcing it, making it optional. This adds an eslint configuration and will exit the Gulp build if it encounters an error.

I tried to follow existing code style as much as possible when applying the rules. There were lots of mixing `'` and `"` so I settled on `"` since those were encountered most frequently.