### PR TITLE
Fix codeblock overflow (issue #6)

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -21,7 +21,7 @@ body {
 	background-color: white;
 	color: hsl(227, 15%, 24%);
 }
-	
+
 	@keyframes pulse {
 		to { line-height: 3; }
 	}
@@ -133,11 +133,11 @@ body > header {
 	padding-top: .5em;
 	font-size: 200%;
 	color: hsl(190, 52%, 50%);
-	
+
 	background: radial-gradient(circle at 50% 90%, white 1em, transparent 0) -2.5em 100% / 5em 5em,
-							radial-gradient(circle at bottom, white 1.5em, hsl(145, 34%, 99%) 2em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 5em 5em,
-							radial-gradient(circle at bottom, white 2em, hsl(145, 34%, 99%) 3em, hsla(145, 34%, 99%, 0) 0) 0 100% / 10em 10em,
-							radial-gradient(circle at bottom, white 3em, hsl(145, 34%, 98%) 4em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 20em 20em;
+	            radial-gradient(circle at bottom, white 1.5em, hsl(145, 34%, 99%) 2em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 5em 5em,
+	            radial-gradient(circle at bottom, white 2em, hsl(145, 34%, 99%) 3em, hsla(145, 34%, 99%, 0) 0) 0 100% / 10em 10em,
+	            radial-gradient(circle at bottom, white 3em, hsl(145, 34%, 98%) 4em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 20em 20em;
 	background-repeat: repeat-x;
 	background-color: hsl(145, 34%, 89%);
 	animation: 20s move infinite linear;
@@ -239,7 +239,7 @@ body > section#intro {}
 
 #docs article:target {
 	background: linear-gradient(hsla(0,0%,100%,.6), white 60%) 0 0 / 100%  8em,
-							repeating-linear-gradient(135deg, hsl(61, 86%, 77%) 0, hsl(61, 86%, 77%) .5em, white 0, white 1em) 0 0 / 100% 8em repeat-x;
+	            repeating-linear-gradient(135deg, hsl(61, 86%, 77%) 0, hsl(61, 86%, 77%) .5em, white 0, white 1em) 0 0 / 100% 8em repeat-x;
 }
 
 body > footer {
@@ -362,10 +362,10 @@ body > footer {
 	#quick-look code {
 		tab-size: 2;
 	}
+}
 
-	body {
-		overflow-x: hidden;
-	}
+body {
+	overflow-x: hidden;
 }
 
 @media (min-width: 50em) and (max-width: 100em) {
@@ -373,7 +373,7 @@ body > footer {
 		font-size: 75%;
 	}
 }
-	
+
 	#quick-look pre::before {
 		position: absolute;
 		bottom: 100%;
@@ -400,8 +400,8 @@ body > footer {
 
 	#quick-look pre.vanilla {
 		background: linear-gradient(to left, hsla(350, 80%, 96%,0), hsl(350, 80%, 96%)),
-								linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
-								hsl(350, 80%, 96%);
+		            linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
+		            hsl(350, 80%, 96%);
 		border-right: .3em solid white;
 	}
 
@@ -413,8 +413,8 @@ body > footer {
 
 	#quick-look pre.bliss {
 		background: linear-gradient(to right, hsla(145, 34%, 95%,0), hsl(145, 34%, 95%)),
-								linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
-								hsl(145, 34%, 95%);
+		            linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
+		            hsl(145, 34%, 95%);
 		padding-left: .8em;
 		border-left: .3em solid white;
 	}
@@ -437,7 +437,7 @@ body > footer {
 	color: #f5ebd6;
 	box-shadow: 0 0.1em 0 0.1em rgba(0, 0, 0, 0.15);
 }
-	
+
 	.github-ribbon:hover {
 		background: black;
 		color: white;

--- a/style/style.css
+++ b/style/style.css
@@ -129,18 +129,18 @@ body > footer {
 }
 
 body > header {
-  position: relative;
-  padding-top: .5em;
-  font-size: 200%;
-  color: hsl(190, 52%, 50%);
-  
-  background: radial-gradient(circle at 50% 90%, white 1em, transparent 0) -2.5em 100% / 5em 5em,
-              radial-gradient(circle at bottom, white 1.5em, hsl(145, 34%, 99%) 2em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 5em 5em,
-              radial-gradient(circle at bottom, white 2em, hsl(145, 34%, 99%) 3em, hsla(145, 34%, 99%, 0) 0) 0 100% / 10em 10em,
-              radial-gradient(circle at bottom, white 3em, hsl(145, 34%, 98%) 4em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 20em 20em;
-  background-repeat: repeat-x;
-  background-color: hsl(145, 34%, 89%);
-  animation: 20s move infinite linear;
+	position: relative;
+	padding-top: .5em;
+	font-size: 200%;
+	color: hsl(190, 52%, 50%);
+	
+	background: radial-gradient(circle at 50% 90%, white 1em, transparent 0) -2.5em 100% / 5em 5em,
+							radial-gradient(circle at bottom, white 1.5em, hsl(145, 34%, 99%) 2em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 5em 5em,
+							radial-gradient(circle at bottom, white 2em, hsl(145, 34%, 99%) 3em, hsla(145, 34%, 99%, 0) 0) 0 100% / 10em 10em,
+							radial-gradient(circle at bottom, white 3em, hsl(145, 34%, 98%) 4em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 20em 20em;
+	background-repeat: repeat-x;
+	background-color: hsl(145, 34%, 89%);
+	animation: 20s move infinite linear;
 }
 
 	body > header:hover {
@@ -238,8 +238,8 @@ body > section#intro {}
 		}
 
 #docs article:target {
-  background: linear-gradient(hsla(0,0%,100%,.6), white 60%) 0 0 / 100%  8em,
-              repeating-linear-gradient(135deg, hsl(61, 86%, 77%) 0, hsl(61, 86%, 77%) .5em, white 0, white 1em) 0 0 / 100% 8em repeat-x;
+	background: linear-gradient(hsla(0,0%,100%,.6), white 60%) 0 0 / 100%  8em,
+							repeating-linear-gradient(135deg, hsl(61, 86%, 77%) 0, hsl(61, 86%, 77%) .5em, white 0, white 1em) 0 0 / 100% 8em repeat-x;
 }
 
 body > footer {
@@ -398,12 +398,12 @@ body > footer {
 		right: 0;
 	}
 
-  #quick-look pre.vanilla {
-    background: linear-gradient(to left, hsla(350, 80%, 96%,0), hsl(350, 80%, 96%)),
-                linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
-                hsl(350, 80%, 96%);
-    border-right: .3em solid white;
-  }
+	#quick-look pre.vanilla {
+		background: linear-gradient(to left, hsla(350, 80%, 96%,0), hsl(350, 80%, 96%)),
+								linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
+								hsl(350, 80%, 96%);
+		border-right: .3em solid white;
+	}
 
 		#quick-look pre.vanilla::before {
 			content: "Plain Vanilla JS";
@@ -411,13 +411,13 @@ body > footer {
 			right: 1em;
 		}
 
-  #quick-look pre.bliss {
-    background: linear-gradient(to right, hsla(145, 34%, 95%,0), hsl(145, 34%, 95%)),
-                linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
-                hsl(145, 34%, 95%);
-    padding-left: .8em;
-    border-left: .3em solid white;
-  }
+	#quick-look pre.bliss {
+		background: linear-gradient(to right, hsla(145, 34%, 95%,0), hsl(145, 34%, 95%)),
+								linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
+								hsl(145, 34%, 95%);
+		padding-left: .8em;
+		border-left: .3em solid white;
+	}
 
 		#quick-look pre.bliss::before {
 			content: "Blissful Vanilla JS";

--- a/style/style.css
+++ b/style/style.css
@@ -129,18 +129,18 @@ body > footer {
 }
 
 body > header {
-	position: relative;
-	padding-top: .5em;
-	font-size: 200%;
-	color: hsl(190, 52%, 50%);
-	
-	background: radial-gradient(circle at 50% 90%, white 1em, transparent 0) -2.5em 100% / 5em 5em,
-							radial-gradient(circle at bottom, white 1.5em, hsl(145, 34%, 99%) 2em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 5em 5em,
-							radial-gradient(circle at bottom, white 2em, hsl(145, 34%, 99%) 3em, hsla(145, 34%, 99%, 0) 0) 0 100% / 10em 10em,
-							radial-gradient(circle at bottom, white 3em, hsl(145, 34%, 98%) 4em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 20em 20em;
-	background-repeat: repeat-x;
-	background-color: hsl(145, 34%, 89%);
-	animation: 20s move infinite linear;
+  position: relative;
+  padding-top: .5em;
+  font-size: 200%;
+  color: hsl(190, 52%, 50%);
+  
+  background: radial-gradient(circle at 50% 90%, white 1em, transparent 0) -2.5em 100% / 5em 5em,
+              radial-gradient(circle at bottom, white 1.5em, hsl(145, 34%, 99%) 2em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 5em 5em,
+              radial-gradient(circle at bottom, white 2em, hsl(145, 34%, 99%) 3em, hsla(145, 34%, 99%, 0) 0) 0 100% / 10em 10em,
+              radial-gradient(circle at bottom, white 3em, hsl(145, 34%, 98%) 4em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 20em 20em;
+  background-repeat: repeat-x;
+  background-color: hsl(145, 34%, 89%);
+  animation: 20s move infinite linear;
 }
 
 	body > header:hover {
@@ -238,8 +238,8 @@ body > section#intro {}
 		}
 
 #docs article:target {
-	background: linear-gradient(hsla(0,0%,100%,.6), white 60%) 0 0 / 100%  8em,
-							repeating-linear-gradient(135deg, hsl(61, 86%, 77%) 0, hsl(61, 86%, 77%) .5em, white 0, white 1em) 0 0 / 100% 8em repeat-x;
+  background: linear-gradient(hsla(0,0%,100%,.6), white 60%) 0 0 / 100%  8em,
+              repeating-linear-gradient(135deg, hsl(61, 86%, 77%) 0, hsl(61, 86%, 77%) .5em, white 0, white 1em) 0 0 / 100% 8em repeat-x;
 }
 
 body > footer {
@@ -398,12 +398,12 @@ body > footer {
 		right: 0;
 	}
 
-	#quick-look pre.vanilla {
-		background: linear-gradient(to left, hsla(350, 80%, 96%,0), hsl(350, 80%, 96%)),
-								linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
-								hsl(350, 80%, 96%);
-		border-right: .3em solid white;
-	}
+  #quick-look pre.vanilla {
+    background: linear-gradient(to left, hsla(350, 80%, 96%,0), hsl(350, 80%, 96%)),
+                linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
+                hsl(350, 80%, 96%);
+    border-right: .3em solid white;
+  }
 
 		#quick-look pre.vanilla::before {
 			content: "Plain Vanilla JS";
@@ -411,13 +411,13 @@ body > footer {
 			right: 1em;
 		}
 
-	#quick-look pre.bliss {
-		background: linear-gradient(to right, hsla(145, 34%, 95%,0), hsl(145, 34%, 95%)),
-								linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
-								hsl(145, 34%, 95%);
-		padding-left: .8em;
-		border-left: .3em solid white;
-	}
+  #quick-look pre.bliss {
+    background: linear-gradient(to right, hsla(145, 34%, 95%,0), hsl(145, 34%, 95%)),
+                linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
+                hsl(145, 34%, 95%);
+    padding-left: .8em;
+    border-left: .3em solid white;
+  }
 
 		#quick-look pre.bliss::before {
 			content: "Blissful Vanilla JS";

--- a/style/style.css
+++ b/style/style.css
@@ -135,9 +135,9 @@ body > header {
 	color: hsl(190, 52%, 50%);
 	
 	background: radial-gradient(circle at 50% 90%, white 1em, transparent 0) -2.5em 100% / 5em 5em,
-	            radial-gradient(circle at bottom, white 1.5em, hsl(145, 34%, 99%) 2em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 5em 5em,
-	            radial-gradient(circle at bottom, white 2em, hsl(145, 34%, 99%) 3em, hsla(145, 34%, 99%, 0) 0) 0 100% / 10em 10em,
-	            radial-gradient(circle at bottom, white 3em, hsl(145, 34%, 98%) 4em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 20em 20em;
+							radial-gradient(circle at bottom, white 1.5em, hsl(145, 34%, 99%) 2em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 5em 5em,
+							radial-gradient(circle at bottom, white 2em, hsl(145, 34%, 99%) 3em, hsla(145, 34%, 99%, 0) 0) 0 100% / 10em 10em,
+							radial-gradient(circle at bottom, white 3em, hsl(145, 34%, 98%) 4em, hsla(145, 34%, 99%, 0) 0) 0em 100% / 20em 20em;
 	background-repeat: repeat-x;
 	background-color: hsl(145, 34%, 89%);
 	animation: 20s move infinite linear;
@@ -239,7 +239,7 @@ body > section#intro {}
 
 #docs article:target {
 	background: linear-gradient(hsla(0,0%,100%,.6), white 60%) 0 0 / 100%  8em,
-	            repeating-linear-gradient(135deg, hsl(61, 86%, 77%) 0, hsl(61, 86%, 77%) .5em, white 0, white 1em) 0 0 / 100% 8em repeat-x;
+							repeating-linear-gradient(135deg, hsl(61, 86%, 77%) 0, hsl(61, 86%, 77%) .5em, white 0, white 1em) 0 0 / 100% 8em repeat-x;
 }
 
 body > footer {
@@ -354,14 +354,17 @@ body > footer {
 
 	#quick-look .comparison pre {
 		position: relative;
-		-webkit-flex: 1;
-		flex: 1;
 		padding: .5em 0;
 		border-radius: .5em;
+		width: 50%;
 	}
 
 	#quick-look code {
 		tab-size: 2;
+	}
+
+	body {
+		overflow-x: hidden;
 	}
 }
 
@@ -397,8 +400,8 @@ body > footer {
 
 	#quick-look pre.vanilla {
 		background: linear-gradient(to left, hsla(350, 80%, 96%,0), hsl(350, 80%, 96%)),
-		            linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
-		            hsl(350, 80%, 96%);
+								linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
+								hsl(350, 80%, 96%);
 		border-right: .3em solid white;
 	}
 
@@ -410,8 +413,8 @@ body > footer {
 
 	#quick-look pre.bliss {
 		background: linear-gradient(to right, hsla(145, 34%, 95%,0), hsl(145, 34%, 95%)),
-		            linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
-		            hsl(145, 34%, 95%);
+								linear-gradient(hsla(0,0%,100%,.5) 50%, transparent 0) 0 0 / auto 3em content-box padding-box
+								hsl(145, 34%, 95%);
 		padding-left: .8em;
 		border-left: .3em solid white;
 	}


### PR DESCRIPTION
This PR is a possible solution for the problem described in #6.
I've tested this in FF 42 on OS X 10.11.1. The Flexbox declarations on the `<pre>` tags have caused the issue there. I've removed the flex declarations, replaced them with a `width: 50%` and gave the body a `overflow-x: hidden;` to cut of the overlapping `::after` elements.

Cheers!