### PR TITLE
Add $.contents tests (passing)

### DIFF
--- a/tests/DOM/ContentsSpec.js
+++ b/tests/DOM/ContentsSpec.js
@@ -1,0 +1,83 @@
+describe("$.contents", function() {
+	it("exists", function() {
+		expect($.contents).to.exist;
+	});
+
+	it("adds nodes to the provided subject", function() {
+		var element = document.createElement("nav");
+
+		$.contents(element, "Test Text");
+		expect(element.childNodes).to.have.length(1);
+
+		$.contents(element, {
+			tag: "li"
+		});
+		expect(element.childNodes).to.have.length(2);
+
+		$.contents(element, ["3", "4"]);
+		expect(element.childNodes).to.have.length(4);
+
+		$.contents(element, [
+			document.createElement("li"),
+			document.createElement("li")
+		]);
+		expect(element.childNodes).to.have.length(6);
+
+		$.contents(element, []);
+		expect(element.childNodes).to.have.length(6);
+	});
+
+	it("can be called on elements", function() {
+		var element = document.createElement("nav");
+
+		element._.contents("Test Text");
+		expect(element.childNodes).to.have.length(1);
+
+		element._.contents({
+			tag: "li"
+		});
+		expect(element.childNodes).to.have.length(2);
+
+		element._.contents(["3", "4"]);
+		expect(element.childNodes).to.have.length(4);
+
+		element._.contents([
+			document.createElement("li"),
+			document.createElement("li")
+		]);
+		expect(element.childNodes).to.have.length(6);
+
+		element._.contents([]);
+		expect(element.childNodes).to.have.length(6);
+	});
+
+	it("can be called on arrays", function() {
+		var list = [
+			document.createElement("li"),
+			document.createElement("li"),
+			document.createElement("li")
+		];
+
+		list._.contents("Test Text");
+		list.forEach(function(item) {
+			expect(item.childNodes).to.have.length(1);
+		});
+
+		list._.contents({
+			tag: "li"
+		});
+		list.forEach(function(item) {
+			expect(item.childNodes).to.have.length(2);
+		});
+
+		list._.contents(["3", "4"]);
+		list.forEach(function(item) {
+			expect(item.childNodes).to.have.length(4);
+		});
+
+		list._.contents([]);
+		list.forEach(function(item) {
+			expect(item.childNodes).to.have.length(4);
+		});
+	});
+});

--- a/tests/DOM/ContentsSpec.js
+++ b/tests/DOM/ContentsSpec.js
@@ -17,11 +17,15 @@ describe("$.contents", function() {
 		$.contents(element, ["3", "4"]);
 		expect(element.childNodes).to.have.length(4);
 
+		var newElement1 = document.createElement("li");
+		var newElement2 = document.createElement("li");
 		$.contents(element, [
-			document.createElement("li"),
-			document.createElement("li")
+			newElement1,
+			newElement2
 		]);
 		expect(element.childNodes).to.have.length(6);
+		expect(element.childNodes[4]).to.equal(newElement1);
+		expect(element.childNodes[5]).to.equal(newElement2);
 
 		$.contents(element, []);
 		expect(element.childNodes).to.have.length(6);
@@ -41,11 +45,15 @@ describe("$.contents", function() {
 		element._.contents(["3", "4"]);
 		expect(element.childNodes).to.have.length(4);
 
+		var newElement1 = document.createElement("li");
+		var newElement2 = document.createElement("li");
 		element._.contents([
-			document.createElement("li"),
-			document.createElement("li")
+			newElement1,
+			newElement2
 		]);
 		expect(element.childNodes).to.have.length(6);
+		expect(element.childNodes[4]).to.equal(newElement1);
+		expect(element.childNodes[5]).to.equal(newElement2);
 
 		element._.contents([]);
 		expect(element.childNodes).to.have.length(6);


### PR DESCRIPTION
Basic idea: create a test node `element`, add node(s) to it using `$.contents`, then assert that the length of `element.childNodes` is as expected. (If DOM nodes were directly added, we also check that the new child nodes are in fact the DOM nodes added.)

Repeat for `element._.contents` and `[elem1, elem2].contents`.