### PR TITLE
Add small test for $.delegate (failing on PhantomJS)

### DIFF
--- a/tests/CoreSpec.js
+++ b/tests/CoreSpec.js
@@ -14,6 +14,11 @@ describe("Core Bliss", function () {
 		expect($('#fixture-container')).to.not.be.null;
 	});
 
+	it("is a valid testing environment", function () {
+		// PhantomJS fails this one by default
+		expect(Element.prototype.matches).to.not.be.undefined;
+	});
+
 	it("has global methods and aliases", function() {
 		expect(Bliss).to.exist;
 		expect($).to.exist;

--- a/tests/CoreSpec.js
+++ b/tests/CoreSpec.js
@@ -14,11 +14,6 @@ describe("Core Bliss", function () {
 		expect($('#fixture-container')).to.not.be.null;
 	});
 
-	it("is a valid testing environment", function () {
-		// PhantomJS fails this one by default
-		expect(Element.prototype.matches).to.not.be.undefined;
-	});
-
 	it("has global methods and aliases", function() {
 		expect(Bliss).to.exist;
 		expect($).to.exist;

--- a/tests/events/DelegateSpec.js
+++ b/tests/events/DelegateSpec.js
@@ -1,0 +1,17 @@
+describe("$.delegate", function() {
+	it("adds event to children of the subject", function(done) {
+		var subject = document.createElement("div");
+		document.body.appendChild(subject);
+
+		var inner = document.createElement("a");
+		subject.appendChild(inner);
+
+		$.delegate(subject, "click", "a", function() {
+			done();
+		});
+
+		var ev = document.createEvent("MouseEvent");
+		ev.initMouseEvent("click", true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+		inner.dispatchEvent(ev);
+	});
+});


### PR DESCRIPTION
Based on a test by @wcastand in LeaVerou/bliss#47. (Thanks!)

This seems to fail on PhantomJS due because `Element.matches` (used in `$.delegate`) is unavailable. Changing `$.delegate` to use `Element.webkitMatchesSelector` makes the test pass.

This test passes as is on Chrome and Firefox Developer.