### PR TITLE
Use mix blend mode isolation on code sections.

### DIFF
--- a/style/prism.css
+++ b/style/prism.css
@@ -14,6 +14,7 @@ pre[class*="language-"] {
 	word-wrap: normal;
 	line-height: 1.5;
 	tab-size: 4;
+	isolation: isolate;
 }
 
 pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,


### PR DESCRIPTION
Code comments are styled with mix-blend-mode: multiply, which currently forces the whole page to be put into a blend mode composition surface, because nothing else on the page creates a stacking context. Doing blending on the whole page hurts performance. It also causes a performance problem specific to Firefox: Firefox doesn't support the "multiply" blend mode in the compositor yet, so it can't accelerate scrolling. (At least starting with Firefox 44 - Firefox up to version 43 has buggy accelerated multiply blending support, so it was turned off in Firefox 44, see bug 1135271.)

Adding isolation: isolate to the code section allows scrolling to be accelerated in recent Firefox versions and makes composition cheaper in all browsers.