### PR TITLE
improvement on docs: suggestion about how to avoid errors when $ returns null

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm test
 - Please follow the existing code style.
 - Do not add new methods before consulting.
 - Remember, code simplicity, readability and conciseness matters a lot for this project. Often juggling the three can be tricky.
-- Right now what Bliss badly needs is **tests**. If you want to contribute, please consider contributing tests!
+- Right now what Bliss badly needs is **tests**. If you want to contribute, please consider contributing tests! See [here](https://github.com/LeaVerou/bliss/blob/gh-pages/tests/README.md) for details.
 
 
 ## Browser Support

--- a/docs.html
+++ b/docs.html
@@ -241,8 +241,8 @@ $(".foo").setAttribute("title", "yolo");</code></pre>
 <pre><code>// Check if the .foo element exists
 // and set an attribute by using a variable "foo"
 // as a reference of the element
-var foo;
-if (foo = $(".foo")) {
+var foo = $(".foo");
+if (foo) {
     foo.setAttribute("title", "yolo");
 }</code></pre>
 

--- a/docs.html
+++ b/docs.html
@@ -233,8 +233,18 @@ var ret = $(".bar .foo");</code></pre>
 $(".foo").setAttribute("title", "yolo");</code></pre>
 
 		<ul class="notes">
-			<li>If the element is not found, it will return <code>null</code>. This could cause an exception if methods are called on the result.</li>
+			<li>If the element is not found, it will return <code>null</code>. This could cause an exception if methods are called on the result.
+			You might previously check if the element exists by caching the node in a variable
+			into an <code>if</code> statement:</li>
 		</ul>
+
+<pre><code>// Check if the .foo element exists
+// and set an attribute by using a variable "foo"
+// as a reference of the element
+var foo;
+if (foo = $(".foo")) {
+    foo.setAttribute("title", "yolo");
+}</code></pre>
 
 		<a href="http://api.jquery.com/jQuery/#jQuery1" class="jq">$</a>
 	</article>


### PR DESCRIPTION
Inserted some code to explain how to previously check if a node retrieved by ```$``` is null, and how to avoid to apply chained methods in this scenario. I think this could be a useful note and it encourages the adoption of a variable as cached reference

the suggested code:

```
// Check if the .foo element exists
// and set an attribute by using a variable "foo"
// as a reference of the element
var foo;
if (foo = $(".foo")) {
    foo.setAttribute("title", "yolo");
}
```

Note: as a side effect of this commit other lines are affected just because of the _autotrim_ function enabled on my ```Atom``` editor