### PR TITLE
Type method refactor

### DIFF
--- a/bliss.js
+++ b/bliss.js
@@ -57,7 +57,8 @@ extend($, {
 		var ret;
 		if(obj === null || obj === undefined) {
 			ret = obj + '';
-		} else {
+		}
+		else {
 			ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
 			if(ret === 'number' && isNaN(obj)) {
 				ret = 'nan';

--- a/bliss.js
+++ b/bliss.js
@@ -54,16 +54,16 @@ extend($, {
 	 * Returns the [[Class]] of an object in lowercase (eg. array, date, regexp, string etc)
 	 */
 	type: function(obj) {
-	  var ret;
-	  if(obj === null || obj === undefined) {
-	    ret = obj + '';
-	  } else {
-	    ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
-	    if(ret === 'number' && isNaN(obj)) {
-	      ret = 'nan';
-	    }
-	  }
-	  return ret;
+		var ret;
+		if(obj === null || obj === undefined) {
+			ret = obj + '';
+		} else {
+			ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
+			if(ret === 'number' && isNaN(obj)) {
+				ret = 'nan';
+			}
+		}
+		return ret;
 	},
 
 	/*

--- a/bliss.js
+++ b/bliss.js
@@ -54,17 +54,16 @@ extend($, {
 	 * Returns the [[Class]] of an object in lowercase (eg. array, date, regexp, string etc)
 	 */
 	type: function(obj) {
-		if (obj === null) { return 'null'; }
-
-		if (obj === undefined) { return 'undefined'; }
-
-		var ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
-
-		if(ret == 'number' && isNaN(obj)) {
-			return 'nan';
-		}
-
-		return ret;
+	  var ret;
+	  if(obj === null || obj === undefined) {
+	    ret = obj + '';
+	  } else {
+	    ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
+	    if(ret === 'number' && isNaN(obj)) {
+	      ret = 'nan';
+	    }
+	  }
+	  return ret;
 	},
 
 	/*

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -57,7 +57,8 @@ extend($, {
 		var ret;
 		if(obj === null || obj === undefined) {
 			ret = obj + '';
-		} else {
+		}
+		else {
 			ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
 			if(ret === 'number' && isNaN(obj)) {
 				ret = 'nan';

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -54,16 +54,16 @@ extend($, {
 	 * Returns the [[Class]] of an object in lowercase (eg. array, date, regexp, string etc)
 	 */
 	type: function(obj) {
-	  var ret;
-	  if(obj === null || obj === undefined) {
-	    ret = obj + '';
-	  } else {
-	    ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
-	    if(ret === 'number' && isNaN(obj)) {
-	      ret = 'nan';
-	    }
-	  }
-	  return ret;
+		var ret;
+		if(obj === null || obj === undefined) {
+			ret = obj + '';
+		} else {
+			ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
+			if(ret === 'number' && isNaN(obj)) {
+				ret = 'nan';
+			}
+		}
+		return ret;
 	},
 
 	/*

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -54,17 +54,16 @@ extend($, {
 	 * Returns the [[Class]] of an object in lowercase (eg. array, date, regexp, string etc)
 	 */
 	type: function(obj) {
-		if (obj === null) { return 'null'; }
-
-		if (obj === undefined) { return 'undefined'; }
-
-		var ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
-
-		if(ret == 'number' && isNaN(obj)) {
-			return 'nan';
-		}
-
-		return ret;
+	  var ret;
+	  if(obj === null || obj === undefined) {
+	    ret = obj + '';
+	  } else {
+	    ret = (Object.prototype.toString.call(obj).match(/^\[object\s+(.*?)\]$/)[1] || "").toLowerCase();
+	    if(ret === 'number' && isNaN(obj)) {
+	      ret = 'nan';
+	    }
+	  }
+	  return ret;
 	},
 
 	/*


### PR DESCRIPTION
I cleaned up the 'type' method a bit. The return path is a lot cleaner and the logic is a little easier to follow.