### PR TITLE
Don't wrap text in table of contents

### DIFF
--- a/style/docs.css
+++ b/style/docs.css
@@ -47,6 +47,7 @@
 
 @media (min-width: 60em) and (min-height: 40em) {
 	#toc {
+		white-space: nowrap;
 		position: fixed;
 		bottom: 0;
 		padding: 1em;


### PR DESCRIPTION
This forces each of the current headings to span only one line, improving readability. For example:

![temp](https://cloud.githubusercontent.com/assets/1940729/11762323/89d4e40c-a097-11e5-97ea-d5fabbec407d.png)

Just wanted to check this has no negative side effects.