### PR TITLE
Fix $.ready example in docs

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -866,7 +866,7 @@ myInput._.fire("input");</code></pre>
 
 		<pre class="examples"><code>// Add a red border to all divs on a page
 $.ready().then(function(){
-	$$("div")._.style("border", "1px solid red");
+	$$("div")._.style({ border: "1px solid red" });
 });</code></pre>
 
 		<a class="jq">jQuery.fn.ready</a>


### PR DESCRIPTION
The documentation example for *$.ready* says:
```javascript
$$("div")._.style("border", "1px solid red");
````
instead of:
```javascript
$$("div")._.style({ border: "1px solid red" });
````
