### PR TITLE
Added stringify method for custom object serialization

### DIFF
--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -34,6 +34,8 @@ var $ = self.Bliss = extend(function(expr, context) {
 	return $.type(expr) === "string"? (context || document).querySelector(expr) : expr || null;
 }, self.Bliss);
 
+var identity = function(a) { return a; };
+
 extend($, {
 	extend: extend,
 
@@ -102,6 +104,23 @@ extend($, {
 		}
 
 		return ret;
+	},
+	
+	stringify: function(obj, o) {
+		o = extend({
+			pair: ": ",
+			line: "\n",
+			key: identity,
+			value: identity
+		}, o);
+
+		var ret = [];
+
+		$.each(obj, function(key, value){
+			ret.push(o.key(key) + o.pair + o.value(value));
+		});
+
+		return ret.join(o.line);
 	},
 
 	ready: function(context) {


### PR DESCRIPTION
It allows custom separators as well as functions to pass keys and values through for maximal flexibility.
For example, URL param serialization would be: 

``` js
$.stringify(data, {pair: "=", line: "&", value: encodeURIComponent});
```

With a different `value` function, one can even have nested URL serialization, as has been requested in #128. 
Adds about 100 bytes to the minified & gzipped result.

Thoughts?
Alternatively, it could be a plugin if you guys don't think it's that useful. 
