### PR TITLE
[Docs] Remove [, on] argument from add when using name as first argument

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -1209,7 +1209,7 @@ $.include(self.Dropbox, url).then(function(){
 		<h1>add</h1>
 		<p class="description">Register new blissful methods that operate on elements and/or arrays. They will be automatically added on Bliss’ element and array property (if on Bliss Full), as well as directly on Bliss itself.</p>
 
-		<pre><code>$.add(name, callback [, on])</code></pre>
+		<pre><code>$.add(name, callback)</code></pre>
 
 		<dl class="args">
 			<dt class="string">name</dt>
@@ -1217,9 +1217,6 @@ $.include(self.Dropbox, url).then(function(){
 
 			<dt class="function">callback</dt>
 			<dd>A function which operates on a single element, as its context (the <code>this</code> keyword). <code>$.add()</code> will take care of the syntactic variations and array handling.</dd>
-
-			<dt class="object">on</dt>
-			<dd>What the function should be added on. The available keys are: <code>$</code>, <code>element</code>, <code>array</code> and their values are <code>true</code> by default so only set them if you want to set them to <code>false</code>.</dd>
 		</dl>
 
 		<pre class="def"><code>$.add(callbacks [, on])</code></pre>


### PR DESCRIPTION
Test: `AddSpec.js`

```javascript
it("currently skips 'on' object when using method name as first argument", function () {
  $.add("bar", function () {}, {
    array: false
  });

  expect([1,2,3]._.bar).to.exist;
  expect($(".foo")._.bar).to.exist;
  expect($.bar).to.exist;
});
```
Perhaps this should be fixed though?
https://github.com/LeaVerou/bliss/issues/110 had a solution but was put on hold.
We should at least modify the documentation until it's fixed.