### PR TITLE
Fix for undefined `this` in event handlers

### DIFF
--- a/bliss._.js
+++ b/bliss._.js
@@ -63,7 +63,7 @@ if (self.EventTarget && "addEventListener" in EventTarget.prototype) {
 	    notEqual = function() { return !equal.apply(this, arguments); };
 
 	EventTarget.prototype.addEventListener = function(type, callback, capture) {
-		if (this[_] && callback) {
+		if (this && this[_] && callback) {
 			var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
 			
 			listeners[type] = listeners[type] || [];

--- a/bliss._.js
+++ b/bliss._.js
@@ -77,7 +77,7 @@ if (self.EventTarget && "addEventListener" in EventTarget.prototype) {
 	};
 
 	EventTarget.prototype.removeEventListener = function(type, callback, capture) {
-		if (this[_] && callback) {
+		if (this && this[_] && callback) {
 			var listeners = this[_].bliss.listeners = this[_].bliss.listeners || {};
 
 			if (listeners[type]) {


### PR DESCRIPTION
`this` is not guaranteed to be defined in `addEventListener`. A third-party lib was adding an event in a strange way which gave me the following error `Uncaught TypeError: Cannot read property '_' of undefined`.