### PR TITLE
Update ExtendSpec.js

### DIFF
--- a/tests/objects/ExtendSpec.js
+++ b/tests/objects/ExtendSpec.js
@@ -16,6 +16,12 @@ describe('$.extend', function() {
 			hobby: 'Fishing',
 			food: 'pasta'
 		};
+	        orgChild = {
+            		id: 30,
+            		name: 'Jim',
+            		hobby: 'Biking',
+            		food: 'pizza'
+        	};
 	});
 
 	it('copies properties from parent to child', function() {
@@ -33,29 +39,25 @@ describe('$.extend', function() {
 	});
 
 	it('takes an array of white list properties', function() {
-		var orgChild = child;
 		$.extend(child, parent, ['hobby', 'food']);
 		
 		expect(child.hobby).to.equal(parent.hobby);
 		expect(child.food).to.equal(parent.food);
-
 		expect(child.name).to.equal(orgChild.name);
-		expect(child.name).to.equal(orgChild.name);
+		expect(child.food).to.not.equal(orgChild.food);
 	});
 
 	it('takes the string "own" to reserve own properties', function() {
-		var orgChild = child;
-		$.extend(child, parent, "own");
-		
-		for(var prop in orgChild) {
-			expect(child[prop]).to.equal(orgChild[prop]);
-		}
-
-		expect(child.location).to.equal(parent.location);
+	        var newParent = Object.create(parent);
+	        newParent.ownProperty = 'Only property that should be added to child';
+	        $.extend(child, newParent, "own");
+	
+	        expect(child.food).to.not.equal(newParent.food);
+	        expect(child.hobby).to.equal(orgChild.hobby);
+	        expect(child.ownProperty).to.equal(newParent.ownProperty);
 	});
 
 	it('takes a function to filter the properties', function() {
-		var orgChild = child;
 		$.extend(child, parent, function(prop) {
 			return prop == 'id';
 		});
@@ -63,13 +65,14 @@ describe('$.extend', function() {
 		expect(child.name).to.equal(orgChild.name);
 		expect(child.location).to.be.undefined;
 		expect(parent.id).to.equal(child.id);
+		expect(child.id).to.not.equal(orgChild.id);
 	});
 
 	it('takes a regular expression for white listing the properties', function() {
-		var orgChild = child;
 		$.extend(child, parent, /^name|^hobby$/);
 
 		expect(child.name).to.equal(parent.name);
+		expect(child.name).to.not.equal(orgChild.name);
 		expect(child.hobby).to.equal(parent.hobby);
 		expect(child.id).to.equal(orgChild.id);
 		expect(child.location).to.be.undefined;


### PR DESCRIPTION
There may be an error in the original $.extend tests with the use of the orgChild variable.  It seems the purpose of the orgChild variable is to retain a copy of the original Child object in order to compare before and after states.  However, the original tests are assigning a child object reference to the orgChild variable, and, because they are pointing at the same object, any equality tests will always pass, regardless of any changes to the original child object.

To fix this, we probably want to clone the child object.  The simplest fix might be to just declare an identical object literal in the beforeEach.  But, of course, there are a half dozen ways to clone an object.

Also, I modified the 'takes the string "own" to reserve own properties' test.  I apologize for including two changes in one pull request, but once I modified the orgChild variable, this test failed and, after further review, didn't really seem to be testing for own's intended usage.