### PR TITLE
Downgrade Sinon due to bug in 1.17.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "karma-mocha": "^0.2.1",
     "karma-sinon": "^1.0.4",
     "mocha": "^2.3.4",
-    "sinon": "^1.17.3"
+    "sinon": "1.17.3"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Sinon 1.17.4 is broken, see: https://github.com/sinonjs/sinon/issues/1040
We should downgrade to 1.17.3 for now, we have failing tests due to this bug.