### PR TITLE
Expose xhr.abort() from Bliss.fetch().

### DIFF
--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -371,7 +371,7 @@ extend($, {
 			env.xhr.setRequestHeader(header, env.headers[header]);
 		}
 
-		return new Promise(function(resolve, reject) {
+		var promise = new Promise(function(resolve, reject) {
 			env.xhr.onload = function() {
 				document.body.removeAttribute("data-loading");
 
@@ -401,6 +401,13 @@ extend($, {
 
 			env.xhr.send(env.method === "GET"? null : env.data);
 		});
+		// Hack: Expose xhr.abort(), by attaching xhr to the promise.
+		// (The caller will need to capture the promise in a variable X (and
+		// call X.xhr.abort()), before chaining with X.then(..) because
+		// the promises returned by the chained calls, won't have the .xhr
+		// field any more.)
+		promise.xhr = env.xhr;
+		return promise;
 	},
 
 	value: function(obj) {

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -402,10 +402,6 @@ extend($, {
 			env.xhr.send(env.method === "GET"? null : env.data);
 		});
 		// Hack: Expose xhr.abort(), by attaching xhr to the promise.
-		// (The caller will need to capture the promise in a variable X (and
-		// call X.xhr.abort()), before chaining with X.then(..) because
-		// the promises returned by the chained calls, won't have the .xhr
-		// field any more.)
 		promise.xhr = env.xhr;
 		return promise;
 	},

--- a/docs.html
+++ b/docs.html
@@ -1218,7 +1218,9 @@ $.value("document", "body", "nodeType"); // 1, no root, starting from self</code
 			<dd>A promise that is resolved when the resource is successfully fetched and rejected if there is any error.
 				When the request is successful, the promise resolves with the XHR object.
 				When the request fails, the promise rejects with an Error whose message is a description of the error.
-				The error object also contains two properties: <code>xhr</code> which points to the XHR object, and <code>status</code> which returns the status code (e.g. 404).</dd>
+				The error object also contains two properties: <code>xhr</code> which points to the XHR object, and
+				<code>status</code> which returns the status code (e.g. 404). In case you need to abort the request,
+				the xhr is returned in a field on the promise, so you can: <code>promise.xhr.abort()</code>.</dd>
 		</dl>
 
 		<pre><code>$.fetch("/api/create", {


### PR DESCRIPTION
`Bliss.fetch()` returns a Promise, via which one cannot access `xhr.abort()`. This PR attaches the xhr to the promise, so one can call `.abort()`. This is a little bit hacky ... but the [HTML5 fetch API & abort stuff](https://developer.mozilla.org/en-US/docs/Web/API/FetchController) looks complicated and is experimental, so perhaps this PR is the best approach for now.

Discussed in this issue: https://github.com/LeaVerou/bliss/issues/198

Right now this PR includes only Bliss.Shy.js — shall I run some build script so the `.min.js` files get updated too, + update the "thick" Bliss js file too? Or do you want to do that (Lea) ?