### PR TITLE
Enable unsetting Bliss' default Content-type by passing undefined

### DIFF
--- a/bliss.js
+++ b/bliss.js
@@ -363,12 +363,18 @@ extend($, {
 			}
 		}
 
-		if (env.method !== "GET" && !env.headers["Content-type"] && !env.headers["Content-Type"]) {
+		var headerKeys = Object.keys(env.headers).map(function(key) {
+			return key.toLowerCase();
+		});
+
+		if (env.method !== "GET" && headerKeys.indexOf("content-type") === -1) {
 			env.xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
 		}
 
 		for (var header in env.headers) {
-			env.xhr.setRequestHeader(header, env.headers[header]);
+			if (env.headers[header] !== undefined) {
+				env.xhr.setRequestHeader(header, env.headers[header]);
+			}
 		}
 
 		var promise = new Promise(function(resolve, reject) {

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -363,12 +363,18 @@ extend($, {
 			}
 		}
 
-		if (env.method !== "GET" && !env.headers["Content-type"] && !env.headers["Content-Type"]) {
+		var headerKeys = Object.keys(env.headers).map(function(key) {
+			return key.toLowerCase();
+		});
+
+		if (env.method !== "GET" && headerKeys.indexOf("content-type") === -1) {
 			env.xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
 		}
 
 		for (var header in env.headers) {
-			env.xhr.setRequestHeader(header, env.headers[header]);
+			if (env.headers[header] !== undefined) {
+				env.xhr.setRequestHeader(header, env.headers[header]);
+			}
 		}
 
 		var promise = new Promise(function(resolve, reject) {


### PR DESCRIPTION
This enables unsetting Bliss' default Content-type (see #202) by passing options:
```js
{headers: {"Content-Type": undefined}}
```

Notes:
1. As you can see, another condition was needed `env.headers[header] !== undefined`. This is because xhr.setRequestHeader treats `undefined` value as `"undefined"` (string). I can make this more explicit if you want (only for "Content-Type" and "Content-type"), but I think it may be going too far for compatibility. I doubt there are any valid case where you'd want to set headers to "undefined" (or am I wrong?), and if you do, you can still pass `"undefined"` instead of `undefined`.
2. I purposely excluded the minified js this time, in order to avoid conflicts.