### PR TITLE
Add linting to ensure line-breaks between "block-like" statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
         "linebreak-style": [1, "unix"],
         "no-lonely-if": 1,
         "no-mixed-spaces-and-tabs": [1, "smart-tabs"],
+        "padding-line-between-statements": [1, {"blankLine": "always", "prev": "block-like", "next": "*"}, {"blankLine": "always", "prev": "*", "next": "block-like"}, {"blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"]}],
         "quotes": [1, "double", "avoid-escape"],
         "spaced-comment": [1, "always"],
         "space-before-blocks": [1, "always"],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "homepage": "http://blissfuljs.com",
   "devDependencies": {
+    "babel-eslint": "^8.0.1",
     "chai": "^3.4.1",
+    "eslint": "^4.10.0",
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
     "gulp-rename": "^1.2.2",
@@ -34,15 +36,13 @@
     "karma": "^0.13.15",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^1.0.1",
+    "karma-eslint": "^2.1.0",
     "karma-fixture": "^0.2.5",
     "karma-html2js-preprocessor": "^0.1.0",
-    "karma-eslint": "^2.1.0",
     "karma-mocha": "^0.2.1",
     "karma-sinon": "^1.0.4",
     "mocha": "^2.3.4",
-    "sinon": "1.17.3",
-    "eslint": "^2.13.0",
-    "babel-eslint": "^6.0.4"
+    "sinon": "1.17.3"
   },
   "dependencies": {}
 }

--- a/tests/arrays/AllSpec.js
+++ b/tests/arrays/AllSpec.js
@@ -17,6 +17,7 @@ describe("$.all", function() {
   it("returns the original array if method returns nothing", function() {
     var Obj = function () {
         this.method = function () {};
+
         return this;
       }, arr = [new Obj(), new Obj(), new Obj()],
       result = $.all(arr, "method");

--- a/tests/arrays/EachSpec.js
+++ b/tests/arrays/EachSpec.js
@@ -18,6 +18,7 @@ describe("$.each", function() {
   
   it("copies properties and inherited properties from one object to new object", function () {
     var parent = function() {};
+
 	parent.prototype.func = function() {};
 	
 	var obj = Object.create(parent.prototype);

--- a/tests/objects/LazySpec.js
+++ b/tests/objects/LazySpec.js
@@ -6,6 +6,7 @@ describe("$.lazy", function() {
 		TestClass = function () { 
 			return this; 
 		};
+
 		testObj = {animals: ["kittens"]};
 	});	
 	


### PR DESCRIPTION
This ensures "block-like" statements are padded with a blank line unless they are variable declarations, using the [padding-line-between-statements](https://eslint.org/docs/4.0.0/rules/padding-line-between-statements)-rule introduced in eslint 4.0.0.

"block-like" means "statements that the last token is the closing brace of blocks; e.g. { }, if (a) { }, and while (a) { }."

This will pass for example:
```js
var foo = "bar";
var baz = function() {
  ...
};
```

And also:
```js
if (expression) {
  ...
}
else if (expression2) {
  ...
}
```

But not:
```js
if (expression) {
  ...
}
if (expression2) {
  ...
}
```

or:

```js
var foo = function() {
  ...
};
foo();
```


Limitations:
Does not apply to object methods. There is a separate issue/suggestion for that called "padded-object", but it's not implemented (and another one for es6 class methods that is implemented, but we can't use that).

I added the rule as warning (since all the existing rules were). It's a single line in ".eslintrc.json", which could be seen as a bit of a contradiction.