### PR TITLE
Fixes 204: $.fetch() upload events

### DIFF
--- a/bliss.js
+++ b/bliss.js
@@ -353,7 +353,12 @@ extend($, {
 		env.xhr.open(env.method, env.url.href, env.async !== false, env.user, env.password);
 
 		for (var property in o) {
-			if (property in env.xhr) {
+			if (property === "upload") {
+				if (env.xhr.upload && typeof o[property] === "object") {
+					$.extend(env.xhr.upload, o[property]);
+				}
+			}
+			else if (property in env.xhr) {
 				try {
 					env.xhr[property] = o[property];
 				}

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -353,7 +353,12 @@ extend($, {
 		env.xhr.open(env.method, env.url.href, env.async !== false, env.user, env.password);
 
 		for (var property in o) {
-			if (property in env.xhr) {
+			if (property === "upload") {
+				if (env.xhr.upload && typeof o[property] === "object") {
+					$.extend(env.xhr.upload, o[property]);
+				}
+			}
+			else if (property in env.xhr) {
 				try {
 					env.xhr[property] = o[property];
 				}


### PR DESCRIPTION
As per discussion in #204.

I was a little bit unsure if `env.xhr.upload` would always be present. I think it always should be regardless of existence of a "body" (for example GET requests), and my tests (latest versions of Chrome, Firefox, Edge, Safari + IE11) confirms this, but I still felt uneasy not checking.

There is no parameter validation besides checking that `upload` is an object. The intention was just to provide access to attaching events to xhr.upload via `$.fetch()`s option params, similar to how it can be done with download events today. Not taking responsibility for how people use it. Unlike the xhr-object, xhr.upload doesn't have any read only-properties, so `try...catch` shouldn't be necessary (at least for that reason) unless the xhr standard changes.