### PR TITLE
Apply editorconfig settings to current code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,21 @@
         "no-lonely-if": 1,
         "no-mixed-spaces-and-tabs": [1, "smart-tabs"],
         "no-trailing-spaces": 1,
-        "padding-line-between-statements": [1, {"blankLine": "always", "prev": "block-like", "next": "*"}, {"blankLine": "always", "prev": "*", "next": "block-like"}, {"blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"]}],
+        "padding-line-between-statements": [1,
+            {
+                "blankLine": "always",
+                "prev": "block-like",
+                "next": "*"
+            }, {
+                "blankLine": "always",
+                "prev": "*",
+                "next": "block-like"
+            }, {
+                "blankLine": "any",
+                "prev": ["const", "let", "var"],
+                "next": ["const", "let", "var"]
+            }
+        ],
         "quotes": [1, "double", "avoid-escape"],
         "spaced-comment": [1, "always"],
         "space-before-blocks": [1, "always"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
         "linebreak-style": [1, "unix"],
         "no-lonely-if": 1,
         "no-mixed-spaces-and-tabs": [1, "smart-tabs"],
+        "no-trailing-spaces": 1,
         "padding-line-between-statements": [1, {"blankLine": "always", "prev": "block-like", "next": "*"}, {"blankLine": "always", "prev": "*", "next": "block-like"}, {"blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"]}],
         "quotes": [1, "double", "avoid-escape"],
         "spaced-comment": [1, "always"],

--- a/bliss._.js
+++ b/bliss._.js
@@ -56,14 +56,14 @@ Object.defineProperty(Array.prototype, _, {
 // Hijack addEventListener and removeEventListener to store callbacks
 
 if (self.EventTarget && "addEventListener" in EventTarget.prototype) {
-	var addEventListener = EventTarget.prototype.addEventListener,
-	    removeEventListener = EventTarget.prototype.removeEventListener,
-	    equal = function(callback, capture, l) {
-			return l.callback === callback && l.capture == capture;
-	    },
-	    notEqual = function() {
-			return !equal.apply(this, arguments);
-		};
+	var addEventListener = EventTarget.prototype.addEventListener;
+	var removeEventListener = EventTarget.prototype.removeEventListener;
+	var equal = function(callback, capture, l) {
+		return l.callback === callback && l.capture == capture;
+	};
+	var notEqual = function() {
+		return !equal.apply(this, arguments);
+	};
 
 	EventTarget.prototype.addEventListener = function(type, callback, capture) {
 		if (this && this[_] && this[_].bliss && callback) {

--- a/bliss._.js
+++ b/bliss._.js
@@ -61,8 +61,8 @@ if (self.EventTarget && "addEventListener" in EventTarget.prototype) {
 	    equal = function(callback, capture, l) {
 			return l.callback === callback && l.capture == capture;
 	    },
-	    notEqual = function() { 
-			return !equal.apply(this, arguments); 
+	    notEqual = function() {
+			return !equal.apply(this, arguments);
 		};
 
 	EventTarget.prototype.addEventListener = function(type, callback, capture) {

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -406,8 +406,8 @@ extend($, {
 			};
 
 			env.xhr.ontimeout = function() {
-			    document.body.removeAttribute("data-loading");
-			    reject($.extend(Error("Network Timeout"), {xhr: env.xhr}));
+				document.body.removeAttribute("data-loading");
+				reject($.extend(Error("Network Timeout"), {xhr: env.xhr}));
 			};
 
 			env.xhr.send(env.method === "GET"? null : env.data);
@@ -421,8 +421,8 @@ extend($, {
 		var hasRoot = $.type(obj) !== "string";
 
 		return $.$(arguments).slice(+hasRoot).reduce(function(obj, property) {
-	        return obj && obj[property];
-	    }, hasRoot? obj : self);
+			return obj && obj[property];
+		}, hasRoot? obj : self);
 	}
 });
 
@@ -541,8 +541,8 @@ $.Element.prototype = {
 					if (!type || ltype === type) {
 						// No forEach, because we’re mutating the array
 						for (var i=0, l; l=listeners[ltype][i]; i++) {
-							if ((!className || className === l.className) &&
-							    (!callback || callback === l.callback )) { // TODO what about capture?
+							// TODO what about capture?
+							if ((!className || className === l.className) && (!callback || callback === l.callback)) {
 								this.removeEventListener(ltype, l.callback, l.capture);
 								i--;
 							}

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -615,7 +615,8 @@ $.setProps = {
 			}
 		}
 		else if (arguments.length > 1 && $.type(val) === "string") {
-			var callback = arguments[1], capture = arguments[2];
+			var callback = arguments[1];
+			var capture = arguments[2];
 
 			val.split(/\s+/).forEach(function (event) {
 				this.addEventListener(event, callback, capture);

--- a/tests/DOM/CloneSpec.js
+++ b/tests/DOM/CloneSpec.js
@@ -3,36 +3,36 @@ describe("$.clone", function() {
 		expect($.clone).to.exist;
 	});
 
-  it("clones events on element", function(done) {
-    var element = document.createElement("div");
-    element.addEventListener("click", function() {
-      done();
-    });
+	it("clones events on element", function(done) {
+		var element = document.createElement("div");
+		element.addEventListener("click", function() {
+			done();
+		});
 
-    var clone = $.clone(element);
+		var clone = $.clone(element);
 
-    var ev = document.createEvent("MouseEvent");
+		var ev = document.createEvent("MouseEvent");
 		ev.initMouseEvent("click", true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-    clone.dispatchEvent(ev);
-  });
+		clone.dispatchEvent(ev);
+	});
 
-  it("clones events on all descendants", function(done) {
-    var element = document.createElement("div");
-    var child = document.createElement("p");
-    var grandchild = document.createElement("span");
+	it("clones events on all descendants", function(done) {
+		var element = document.createElement("div");
+		var child = document.createElement("p");
+		var grandchild = document.createElement("span");
 
-    grandchild.addEventListener("click", function() {
-      done();
-    });
+		grandchild.addEventListener("click", function() {
+			done();
+		});
 
-    child.appendChild(grandchild);
-    element.appendChild(child);
+		child.appendChild(grandchild);
+		element.appendChild(child);
 
-    var clone = $.clone(element);
+		var clone = $.clone(element);
 
-    var ev = document.createEvent("MouseEvent");
+		var ev = document.createEvent("MouseEvent");
 		ev.initMouseEvent("click", true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-    clone.querySelector("p span").dispatchEvent(ev);
-  });
+		clone.querySelector("p span").dispatchEvent(ev);
+	});
 
 });

--- a/tests/DOM/InsideSpec.js
+++ b/tests/DOM/InsideSpec.js
@@ -1,126 +1,126 @@
 describe("$.inside() API", function() {
 
-  it("exists", function() {
+	it("exists", function() {
 		expect($.inside).to.exist;
 	});
 
-  it("inserts an element after other contents", function() {
+	it("inserts an element after other contents", function() {
 
-    var div1 = $.create("div", { id: "div1" });
-    var para0 = $.create("p", { id: "para0", contents: "para0" });
-    var para1 = $.create("p", { id: "para1", contents: "para1" });
-    var elements;
+		var div1 = $.create("div", { id: "div1" });
+		var para0 = $.create("p", { id: "para0", contents: "para0" });
+		var para1 = $.create("p", { id: "para1", contents: "para1" });
+		var elements;
 
-    $("body").appendChild(div1);
+		$("body").appendChild(div1);
 
-    elements = $$("#div1");
+		elements = $$("#div1");
 
-    expect(elements.length).to.equal(1);
+		expect(elements.length).to.equal(1);
 
-    $.inside(para1, div1);
+		$.inside(para1, div1);
 
-    elements = $$("#div1");
+		elements = $$("#div1");
 
-    expect(elements[0].childNodes[0].id).to.equal("para1");
+		expect(elements[0].childNodes[0].id).to.equal("para1");
 
-    $.inside(para0, div1);
+		$.inside(para0, div1);
 
-    expect(elements[0].childNodes[0].id).to.equal("para1");
-    expect(elements[0].childNodes[1].id).to.equal("para0");
+		expect(elements[0].childNodes[0].id).to.equal("para1");
+		expect(elements[0].childNodes[1].id).to.equal("para0");
 
-    // Cleanup.
-    $("body").removeChild(div1);
+		// Cleanup.
+		$("body").removeChild(div1);
 
-  });
+	});
 
-  it('inserts an element with "_.inside()" after other contents', function() {
+	it('inserts an element with "_.inside()" after other contents', function() {
 
-    var div1 = $.create("div", { id: "div1" });
-    var para0 = $.create("p", { id: "para0", contents: "para0" });
-    var para1 = $.create("p", { id: "para1", contents: "para1" });
-    var elements;
+		var div1 = $.create("div", { id: "div1" });
+		var para0 = $.create("p", { id: "para0", contents: "para0" });
+		var para1 = $.create("p", { id: "para1", contents: "para1" });
+		var elements;
 
-    $("body").appendChild(div1);
+		$("body").appendChild(div1);
 
-    elements = $$("#div1");
+		elements = $$("#div1");
 
-    expect(elements.length).to.equal(1);
+		expect(elements.length).to.equal(1);
 
-    para1._.inside(div1);
+		para1._.inside(div1);
 
-    elements = $$("#div1");
+		elements = $$("#div1");
 
-    expect(elements[0].childNodes[0].id).to.equal("para1");
+		expect(elements[0].childNodes[0].id).to.equal("para1");
 
-    para0._.inside(div1);
+		para0._.inside(div1);
 
-    expect(elements[0].childNodes[0].id).to.equal("para1");
-    expect(elements[0].childNodes[1].id).to.equal("para0");
+		expect(elements[0].childNodes[0].id).to.equal("para1");
+		expect(elements[0].childNodes[1].id).to.equal("para0");
 
-    // Cleanup.
-    $("body").removeChild(div1);
+		// Cleanup.
+		$("body").removeChild(div1);
 
-  });
+	});
 
-  it('inserts an element with "_.set({ inside: element })" after other contents', function() {
+	it('inserts an element with "_.set({ inside: element })" after other contents', function() {
 
-    var div1 = $.create("div", { id: "div1" });
-    var para0 = $.create("p", { id: "para0", contents: "para0" });
-    var para1 = $.create("p", { id: "para1", contents: "para1" });
-    var elements;
+		var div1 = $.create("div", { id: "div1" });
+		var para0 = $.create("p", { id: "para0", contents: "para0" });
+		var para1 = $.create("p", { id: "para1", contents: "para1" });
+		var elements;
 
-    $("body").appendChild(div1);
+		$("body").appendChild(div1);
 
-    elements = $$("#div1");
+		elements = $$("#div1");
 
-    expect(elements.length).to.equal(1);
+		expect(elements.length).to.equal(1);
 
-    para1._.set({ inside: div1 });
+		para1._.set({ inside: div1 });
 
-    elements = $$("#div1");
+		elements = $$("#div1");
 
-    expect(elements[0].childNodes[0].id).to.equal("para1");
+		expect(elements[0].childNodes[0].id).to.equal("para1");
 
-    para0._.set({ inside: div1 });
+		para0._.set({ inside: div1 });
 
-    expect(elements[0].childNodes[0].id).to.equal("para1");
-    expect(elements[0].childNodes[1].id).to.equal("para0");
+		expect(elements[0].childNodes[0].id).to.equal("para1");
+		expect(elements[0].childNodes[1].id).to.equal("para0");
 
-    // Cleanup.
-    $("body").removeChild(div1);
+		// Cleanup.
+		$("body").removeChild(div1);
 
-  });
+	});
 
-  it("inserts a nested element after other nested elements", function() {
+	it("inserts a nested element after other nested elements", function() {
 
-    var ul1 = $.create("ul", {
-      contents: [
-        {
-          tag: "li",
-          contents: "hello1"
-        }
-      ]
-    });
+		var ul1 = $.create("ul", {
+			contents: [
+				{
+					tag: "li",
+					contents: "hello1"
+				}
+			]
+		});
 
-    var li1 = ul1.childNodes[0];
-    var li2 = $.create("li", { contents: "hello0" });
-    var elements;
+		var li1 = ul1.childNodes[0];
+		var li2 = $.create("li", { contents: "hello0" });
+		var elements;
 
-    $("body").appendChild(ul1);
+		$("body").appendChild(ul1);
 
-    elements = $$("li");
+		elements = $$("li");
 
-    expect(elements.length).to.equal(1);
+		expect(elements.length).to.equal(1);
 
-    $.inside(li2, ul1);
+		$.inside(li2, ul1);
 
-    elements = $$("li");
+		elements = $$("li");
 
-    expect(elements[0].textContent).to.be.equal("hello1");
-    expect(elements[1].textContent).to.be.equal("hello0");
+		expect(elements[0].textContent).to.be.equal("hello1");
+		expect(elements[1].textContent).to.be.equal("hello0");
 
-    $("body").removeChild(ul1);
+		$("body").removeChild(ul1);
 
-  });
+	});
 
 });

--- a/tests/DOM/PropertiesSpec.js
+++ b/tests/DOM/PropertiesSpec.js
@@ -1,255 +1,255 @@
 describe("$.properties", function() {
 
-  it("exists", function() {
-    expect($.properties).to.exist;
-  });
+	it("exists", function() {
+		expect($.properties).to.exist;
+	});
 
-  it("sets some properties on an element", function() {
+	it("sets some properties on an element", function() {
 
-      var input = document.createElement("input");
+		var input = document.createElement("input");
 
-      expect(input.disabled).to.be.false;
-      expect(input.defaultChecked).to.be.false;
-      expect(input.type).to.be.equal("text");
-      expect(input.className).to.be.equal("");
-      expect(input.value).to.be.equal("");
-      expect(input.onClick).to.be.undefined;
+		expect(input.disabled).to.be.false;
+		expect(input.defaultChecked).to.be.false;
+		expect(input.type).to.be.equal("text");
+		expect(input.className).to.be.equal("");
+		expect(input.value).to.be.equal("");
+		expect(input.onClick).to.be.undefined;
 
-      $.properties(input, {
-        type: "radio",
-        disabled: true,
-        defaultChecked: true,
-        className: "hotline-bling",
-        value: "drake",
-        onClick: function() {
-          console.log("here");
-        }
-      });
+		$.properties(input, {
+			type: "radio",
+			disabled: true,
+			defaultChecked: true,
+			className: "hotline-bling",
+			value: "drake",
+			onClick: function() {
+				console.log("here");
+			}
+		});
 
-      expect(input.disabled).to.equal(true);
-      expect(input.defaultChecked).to.equal(true);
-      expect(input.type).to.equal("radio");
-      expect(input.className).to.equal("hotline-bling");
-      expect(input.value).to.equal("drake");
-      expect(input.onClick).to.be.instanceof(Function);
+		expect(input.disabled).to.equal(true);
+		expect(input.defaultChecked).to.equal(true);
+		expect(input.type).to.equal("radio");
+		expect(input.className).to.equal("hotline-bling");
+		expect(input.value).to.equal("drake");
+		expect(input.onClick).to.be.instanceof(Function);
 
-  });
+	});
 
-  it('sets some properties on an element using the "_" namespace', function() {
+	it('sets some properties on an element using the "_" namespace', function() {
 
-      var input = document.createElement("input");
+		var input = document.createElement("input");
 
-      expect(input.disabled).to.be.false;
-      expect(input.defaultChecked).to.be.false;
-      expect(input.type).to.be.equal("text");
-      expect(input.className).to.be.equal("");
-      expect(input.value).to.be.equal("");
-      expect(input.onClick).to.be.undefined;
+		expect(input.disabled).to.be.false;
+		expect(input.defaultChecked).to.be.false;
+		expect(input.type).to.be.equal("text");
+		expect(input.className).to.be.equal("");
+		expect(input.value).to.be.equal("");
+		expect(input.onClick).to.be.undefined;
 
-      input._.properties({
-        type: "radio",
-        disabled: true,
-        defaultChecked: true,
-        className: "hotline-bling",
-        value: "drake",
-        onClick: function() {
-          console.log("here");
-        }
-      });
+		input._.properties({
+			type: "radio",
+			disabled: true,
+			defaultChecked: true,
+			className: "hotline-bling",
+			value: "drake",
+			onClick: function() {
+				console.log("here");
+			}
+		});
 
-      expect(input.disabled).to.equal(true);
-      expect(input.defaultChecked).to.equal(true);
-      expect(input.type).to.equal("radio");
-      expect(input.className).to.equal("hotline-bling");
-      expect(input.value).to.equal("drake");
-      expect(input.onClick).to.be.instanceof(Function);
+		expect(input.disabled).to.equal(true);
+		expect(input.defaultChecked).to.equal(true);
+		expect(input.type).to.equal("radio");
+		expect(input.className).to.equal("hotline-bling");
+		expect(input.value).to.equal("drake");
+		expect(input.onClick).to.be.instanceof(Function);
 
-  });
+	});
 
-  it('sets some properties on an element using the "set" namespace', function() {
+	it('sets some properties on an element using the "set" namespace', function() {
 
-      var input = document.createElement("input");
+		var input = document.createElement("input");
 
-      expect(input.disabled).to.be.false;
-      expect(input.defaultChecked).to.be.false;
-      expect(input.type).to.be.equal("text");
-      expect(input.className).to.be.equal("");
-      expect(input.value).to.be.equal("");
-      expect(input.onClick).to.be.undefined;
+		expect(input.disabled).to.be.false;
+		expect(input.defaultChecked).to.be.false;
+		expect(input.type).to.be.equal("text");
+		expect(input.className).to.be.equal("");
+		expect(input.value).to.be.equal("");
+		expect(input.onClick).to.be.undefined;
 
-      input._.set({ properties: {
-          type: "radio",
-          disabled: true,
-          defaultChecked: true,
-          className: "hotline-bling",
-          value: "drake",
-          onClick: function() {
-            console.log("here");
-          }
-        }
-      });
+		input._.set({ properties: {
+			type: "radio",
+			disabled: true,
+			defaultChecked: true,
+			className: "hotline-bling",
+			value: "drake",
+			onClick: function() {
+				console.log("here");
+			}
+		}
+		});
 
-      expect(input.disabled).to.equal(true);
-      expect(input.defaultChecked).to.equal(true);
-      expect(input.type).to.equal("radio");
-      expect(input.className).to.equal("hotline-bling");
-      expect(input.value).to.equal("drake");
-      expect(input.onClick).to.be.instanceof(Function);
+		expect(input.disabled).to.equal(true);
+		expect(input.defaultChecked).to.equal(true);
+		expect(input.type).to.equal("radio");
+		expect(input.className).to.equal("hotline-bling");
+		expect(input.value).to.equal("drake");
+		expect(input.onClick).to.be.instanceof(Function);
 
-  });
+	});
 
-  it("sets some properties on an array of elements", function() {
+	it("sets some properties on an array of elements", function() {
 
-      var arr = [
-        document.createElement("input"),
-        document.createElement("input"),
-        document.createElement("input")
-      ];
+		var arr = [
+			document.createElement("input"),
+			document.createElement("input"),
+			document.createElement("input")
+		];
 
-      arr.forEach(function(input) {
-        expect(input.disabled).to.be.false;
-        expect(input.defaultChecked).to.be.false;
-        expect(input.type).to.be.equal("text");
-        expect(input.className).to.be.equal("");
-        expect(input.value).to.be.equal("");
-        expect(input.onClick).to.be.undefined;
-      });
+		arr.forEach(function(input) {
+			expect(input.disabled).to.be.false;
+			expect(input.defaultChecked).to.be.false;
+			expect(input.type).to.be.equal("text");
+			expect(input.className).to.be.equal("");
+			expect(input.value).to.be.equal("");
+			expect(input.onClick).to.be.undefined;
+		});
 
-      $.properties(arr, {
-        type: "radio",
-        disabled: true,
-        defaultChecked: true,
-        className: "hotline-bling",
-        value: "drake",
-        onClick: function() {
-          console.log("here");
-        }
-      });
+		$.properties(arr, {
+			type: "radio",
+			disabled: true,
+			defaultChecked: true,
+			className: "hotline-bling",
+			value: "drake",
+			onClick: function() {
+				console.log("here");
+			}
+		});
 
-      arr.forEach(function(input) {
-        expect(input.disabled).to.equal(true);
-        expect(input.defaultChecked).to.equal(true);
-        expect(input.type).to.equal("radio");
-        expect(input.className).to.equal("hotline-bling");
-        expect(input.value).to.equal("drake");
-        expect(input.onClick).to.be.instanceof(Function);
-      });
+		arr.forEach(function(input) {
+			expect(input.disabled).to.equal(true);
+			expect(input.defaultChecked).to.equal(true);
+			expect(input.type).to.equal("radio");
+			expect(input.className).to.equal("hotline-bling");
+			expect(input.value).to.equal("drake");
+			expect(input.onClick).to.be.instanceof(Function);
+		});
 
-  });
+	});
 
-  it('sets some properties on an array of elements with the "_" namespace', function() {
+	it('sets some properties on an array of elements with the "_" namespace', function() {
 
-      var arr = [
-        document.createElement("input"),
-        document.createElement("input"),
-        document.createElement("input")
-      ];
+		var arr = [
+			document.createElement("input"),
+			document.createElement("input"),
+			document.createElement("input")
+		];
 
-      arr.forEach(function(input) {
-        expect(input.disabled).to.be.false;
-        expect(input.defaultChecked).to.be.false;
-        expect(input.type).to.be.equal("text");
-        expect(input.className).to.be.equal("");
-        expect(input.value).to.be.equal("");
-        expect(input.onClick).to.be.undefined;
-      });
+		arr.forEach(function(input) {
+			expect(input.disabled).to.be.false;
+			expect(input.defaultChecked).to.be.false;
+			expect(input.type).to.be.equal("text");
+			expect(input.className).to.be.equal("");
+			expect(input.value).to.be.equal("");
+			expect(input.onClick).to.be.undefined;
+		});
 
-      arr._.properties({
-        type: "radio",
-        disabled: true,
-        defaultChecked: true,
-        className: "hotline-bling",
-        value: "drake",
-        onClick: function() {
-          console.log("here");
-        }
-      });
+		arr._.properties({
+			type: "radio",
+			disabled: true,
+			defaultChecked: true,
+			className: "hotline-bling",
+			value: "drake",
+			onClick: function() {
+				console.log("here");
+			}
+		});
 
-      arr.forEach(function(input) {
-        expect(input.disabled).to.equal(true);
-        expect(input.defaultChecked).to.equal(true);
-        expect(input.type).to.equal("radio");
-        expect(input.className).to.equal("hotline-bling");
-        expect(input.value).to.equal("drake");
-        expect(input.onClick).to.be.instanceof(Function);
-      });
+		arr.forEach(function(input) {
+			expect(input.disabled).to.equal(true);
+			expect(input.defaultChecked).to.equal(true);
+			expect(input.type).to.equal("radio");
+			expect(input.className).to.equal("hotline-bling");
+			expect(input.value).to.equal("drake");
+			expect(input.onClick).to.be.instanceof(Function);
+		});
 
-  });
+	});
 
-  it('sets some properties on an array of elements with the "set" namespace', function() {
+	it('sets some properties on an array of elements with the "set" namespace', function() {
 
-      var arr = [
-        document.createElement("input"),
-        document.createElement("input"),
-        document.createElement("input")
-      ];
+		var arr = [
+			document.createElement("input"),
+			document.createElement("input"),
+			document.createElement("input")
+		];
 
-      arr.forEach(function(input) {
-        expect(input.disabled).to.be.false;
-        expect(input.defaultChecked).to.be.false;
-        expect(input.type).to.be.equal("text");
-        expect(input.className).to.be.equal("");
-        expect(input.value).to.be.equal("");
-        expect(input.onClick).to.be.undefined;
-      });
+		arr.forEach(function(input) {
+			expect(input.disabled).to.be.false;
+			expect(input.defaultChecked).to.be.false;
+			expect(input.type).to.be.equal("text");
+			expect(input.className).to.be.equal("");
+			expect(input.value).to.be.equal("");
+			expect(input.onClick).to.be.undefined;
+		});
 
-      arr._.set({ properties: {
-          type: "radio",
-          disabled: true,
-          defaultChecked: true,
-          className: "hotline-bling",
-          value: "drake",
-          onClick: function() {
-            console.log("here");
-          }
-        }
-      });
+		arr._.set({ properties: {
+			type: "radio",
+			disabled: true,
+			defaultChecked: true,
+			className: "hotline-bling",
+			value: "drake",
+			onClick: function() {
+				console.log("here");
+			}
+		}
+		});
 
-      arr.forEach(function(input) {
-        expect(input.disabled).to.equal(true);
-        expect(input.defaultChecked).to.equal(true);
-        expect(input.type).to.equal("radio");
-        expect(input.className).to.equal("hotline-bling");
-        expect(input.value).to.equal("drake");
-        expect(input.onClick).to.be.instanceof(Function);
-      });
+		arr.forEach(function(input) {
+			expect(input.disabled).to.equal(true);
+			expect(input.defaultChecked).to.equal(true);
+			expect(input.type).to.equal("radio");
+			expect(input.className).to.equal("hotline-bling");
+			expect(input.value).to.equal("drake");
+			expect(input.onClick).to.be.instanceof(Function);
+		});
 
-  });
+	});
 
-  it("allows chaining on elements", function() {
+	it("allows chaining on elements", function() {
 
-    var input = document.createElement("input");
+		var input = document.createElement("input");
 
-    $.properties(input, {
-      className: "hotline-bling"
-    })._.properties({
-      type: "radio"
-    });
+		$.properties(input, {
+			className: "hotline-bling"
+		})._.properties({
+			type: "radio"
+		});
 
-    expect(input.className).to.equal("hotline-bling");
-    expect(input.type).to.equal("radio");
+		expect(input.className).to.equal("hotline-bling");
+		expect(input.type).to.equal("radio");
 
-  });
+	});
 
-  it("allows chaining on arrays of elements", function() {
+	it("allows chaining on arrays of elements", function() {
 
-    var arr = [
-      document.createElement("input"),
-      document.createElement("input"),
-      document.createElement("input")
-    ];
+		var arr = [
+			document.createElement("input"),
+			document.createElement("input"),
+			document.createElement("input")
+		];
 
-    $.properties(arr, {
-      className: "hotline-bling"
-    })._.properties({
-      type: "radio"
-    });
+		$.properties(arr, {
+			className: "hotline-bling"
+		})._.properties({
+			type: "radio"
+		});
 
-    arr.forEach(function(input) {
-      expect(input.className).to.equal("hotline-bling");
-      expect(input.type).to.equal("radio");
-    });
+		arr.forEach(function(input) {
+			expect(input.className).to.equal("hotline-bling");
+			expect(input.type).to.equal("radio");
+		});
 
-  });
+	});
 
 });

--- a/tests/DOM/PropertiesSpec.js
+++ b/tests/DOM/PropertiesSpec.js
@@ -21,7 +21,7 @@ describe("$.properties", function() {
         defaultChecked: true,
         className: "hotline-bling",
         value: "drake",
-        onClick: function() { 
+        onClick: function() {
           console.log("here");
         }
       });
@@ -52,8 +52,8 @@ describe("$.properties", function() {
         defaultChecked: true,
         className: "hotline-bling",
         value: "drake",
-        onClick: function() { 
-          console.log("here"); 
+        onClick: function() {
+          console.log("here");
         }
       });
 
@@ -83,8 +83,8 @@ describe("$.properties", function() {
           defaultChecked: true,
           className: "hotline-bling",
           value: "drake",
-          onClick: function() { 
-            console.log("here"); 
+          onClick: function() {
+            console.log("here");
           }
         }
       });
@@ -121,8 +121,8 @@ describe("$.properties", function() {
         defaultChecked: true,
         className: "hotline-bling",
         value: "drake",
-        onClick: function() { 
-          console.log("here"); 
+        onClick: function() {
+          console.log("here");
         }
       });
 
@@ -160,8 +160,8 @@ describe("$.properties", function() {
         defaultChecked: true,
         className: "hotline-bling",
         value: "drake",
-        onClick: function() { 
-          console.log("here"); 
+        onClick: function() {
+          console.log("here");
         }
       });
 
@@ -199,8 +199,8 @@ describe("$.properties", function() {
           defaultChecked: true,
           className: "hotline-bling",
           value: "drake",
-          onClick: function() { 
-            console.log("here"); 
+          onClick: function() {
+            console.log("here");
           }
         }
       });

--- a/tests/DOM/QuerySelectorAllSpec.js
+++ b/tests/DOM/QuerySelectorAllSpec.js
@@ -1,56 +1,56 @@
 describe("$$() API", function() {
 
-  helpers.fixture("querySelector.html");
+	helpers.fixture("querySelector.html");
 
-  it("returns a collection of one element when selecting an ID", function() {
+	it("returns a collection of one element when selecting an ID", function() {
 
-    var elements = $$("#fixture-container");
+		var elements = $$("#fixture-container");
 
-    expect(elements).to.be.an.instanceOf(Array);
-    expect(elements.length).to.be.equal(1);
-    expect(elements[0].children.length).to.be.equal(2);
+		expect(elements).to.be.an.instanceOf(Array);
+		expect(elements.length).to.be.equal(1);
+		expect(elements[0].children.length).to.be.equal(2);
 
 	});
 
-  it("returns a collection for selecting elements with a class", function() {
+	it("returns a collection for selecting elements with a class", function() {
 
-    var elements = $$(".list");
+		var elements = $$(".list");
 
-    expect(elements).to.be.an.instanceOf(Array);
-    expect(elements.length).to.be.equal(2);
+		expect(elements).to.be.an.instanceOf(Array);
+		expect(elements.length).to.be.equal(2);
 
-  });
+	});
 
-  it("returns a collection for selecting elements without a context", function() {
+	it("returns a collection for selecting elements without a context", function() {
 
-    var elements = $$("li");
+		var elements = $$("li");
 
-    expect(elements).to.be.an.instanceOf(Array);
-    expect(elements.length).to.be.equal(6);
+		expect(elements).to.be.an.instanceOf(Array);
+		expect(elements.length).to.be.equal(6);
 
-  });
+	});
 
 
-  it("returns a collection inside of a context", function() {
+	it("returns a collection inside of a context", function() {
 
-    var elements = $$("li", $(".list"));
+		var elements = $$("li", $(".list"));
 
-    expect(elements).to.be.an.instanceOf(Array);
-    expect(elements.length).to.be.equal(3);
+		expect(elements).to.be.an.instanceOf(Array);
+		expect(elements.length).to.be.equal(3);
 
-  });
+	});
 
-  it("returns a collection that can be iterated over", function() {
+	it("returns a collection that can be iterated over", function() {
 
-    var elements = $$("li");
-    var count = 0;
+		var elements = $$("li");
+		var count = 0;
 
-    elements.forEach(function() {
-        count += 1;
-    });
+		elements.forEach(function() {
+			count += 1;
+		});
 
-    expect(count).to.be.equal(6);
+		expect(count).to.be.equal(6);
 
-  });
+	});
 
 });

--- a/tests/DOM/QuerySelectorSpec.js
+++ b/tests/DOM/QuerySelectorSpec.js
@@ -1,44 +1,44 @@
 describe("$() API", function() {
 
-  helpers.fixture("querySelector.html");
+	helpers.fixture("querySelector.html");
 
-  it("returns the first element with an ID", function() {
+	it("returns the first element with an ID", function() {
 
-    var element = $("#fixture-container");
+		var element = $("#fixture-container");
 
-    expect(element).to.be.an.instanceOf(Element);
-    expect(element.tagName).to.be.equal("DIV");
-    expect(element.length).to.be.undefined;
-    expect(element.children.length).to.be.equal(2);
+		expect(element).to.be.an.instanceOf(Element);
+		expect(element.tagName).to.be.equal("DIV");
+		expect(element.length).to.be.undefined;
+		expect(element.children.length).to.be.equal(2);
 
 	});
 
-  it("returns the first element with a class", function() {
+	it("returns the first element with a class", function() {
 
-    var element = $("#fixture-container .list");
+		var element = $("#fixture-container .list");
 
-    expect(element).to.be.an.instanceOf(Element);
-    expect(element.tagName).to.be.equal("UL");
-    expect(element.length).to.be.undefined;
-    expect(element.children.length).to.be.equal(3);
+		expect(element).to.be.an.instanceOf(Element);
+		expect(element.tagName).to.be.equal("UL");
+		expect(element.length).to.be.undefined;
+		expect(element.children.length).to.be.equal(3);
 
-    // Test the same idea using context
-    element = $("li", $(".list"));
+		// Test the same idea using context
+		element = $("li", $(".list"));
 
-    expect(element).to.be.an.instanceOf(Element);
-    expect(element.tagName).to.be.equal("LI");
-    expect(element.length).to.be.undefined;
+		expect(element).to.be.an.instanceOf(Element);
+		expect(element.tagName).to.be.equal("LI");
+		expect(element.length).to.be.undefined;
 
-  });
+	});
 
-  it("returns a regular element that you can use the native JS APIs on", function() {
+	it("returns a regular element that you can use the native JS APIs on", function() {
 
-    var element = $("li", $(".list"));
+		var element = $("li", $(".list"));
 
-    element.setAttribute("data-drake", "hotline bling");
+		element.setAttribute("data-drake", "hotline bling");
 
-    expect(element.getAttribute("data-drake")).to.equal("hotline bling");
+		expect(element.getAttribute("data-drake")).to.equal("hotline bling");
 
-  });
+	});
 
 });

--- a/tests/DOM/StartSpec.js
+++ b/tests/DOM/StartSpec.js
@@ -10,7 +10,7 @@ describe("$.start()", function () {
 
 	beforeEach(function () {
 		testContainer = document.getElementById("fixture-container");
-		
+
 		para = document.createElement("p");
 		para.setAttribute("id", "para");
 	});

--- a/tests/DOM/StyleSpec.js
+++ b/tests/DOM/StyleSpec.js
@@ -1,157 +1,157 @@
 describe("$.style", function() {
-    it("exists", function() {
-        expect($.style).to.exist;
-    });
+	it("exists", function() {
+		expect($.style).to.exist;
+	});
 
-    it("sets simple style to element", function() {
-        var el = document.createElement("li");
+	it("sets simple style to element", function() {
+		var el = document.createElement("li");
 
-        $.style(el, {
-            color: "red"
-        });
+		$.style(el, {
+			color: "red"
+		});
 
-        expect(el.style.color).to.equal("red");
-    });
+		expect(el.style.color).to.equal("red");
+	});
 
-    it("sets simple style to element using _ operator", function() {
-        var el = document.createElement("li");
+	it("sets simple style to element using _ operator", function() {
+		var el = document.createElement("li");
 
-        el._.style({
-            color: "red"
-        });
+		el._.style({
+			color: "red"
+		});
 
-        expect(el.style.color).to.equal("red");
-    });
+		expect(el.style.color).to.equal("red");
+	});
 
-    it("sets multiple styles to element", function() {
-        var el = document.createElement("li");
+	it("sets multiple styles to element", function() {
+		var el = document.createElement("li");
 
-        $.style(el, {
-            color: "red",
-            backgroundColor: "white",
-            fontSize: "20px"
-        });
+		$.style(el, {
+			color: "red",
+			backgroundColor: "white",
+			fontSize: "20px"
+		});
 
-        expect(el.style.color).to.equal("red");
-        expect(el.style.backgroundColor).to.equal("white");
-        expect(el.style.fontSize).to.equal("20px");
-    });
+		expect(el.style.color).to.equal("red");
+		expect(el.style.backgroundColor).to.equal("white");
+		expect(el.style.fontSize).to.equal("20px");
+	});
 
-    it("sets multiple styles to element using _ operator", function() {
-        var el = document.createElement("li");
+	it("sets multiple styles to element using _ operator", function() {
+		var el = document.createElement("li");
 
-        el._.style({
-            color: "red",
-            backgroundColor: "white",
-            fontSize: "20px"
-        });
+		el._.style({
+			color: "red",
+			backgroundColor: "white",
+			fontSize: "20px"
+		});
 
-        expect(el.style.color).to.equal("red");
-        expect(el.style.backgroundColor).to.equal("white");
-        expect(el.style.fontSize).to.equal("20px");
-    });
+		expect(el.style.color).to.equal("red");
+		expect(el.style.backgroundColor).to.equal("white");
+		expect(el.style.fontSize).to.equal("20px");
+	});
 
-    it("sets simple style to array", function() {
-        var arr = [
-                document.createElement("li"),
-                document.createElement("li"),
-                document.createElement("li")
-            ];
+	it("sets simple style to array", function() {
+		var arr = [
+			document.createElement("li"),
+			document.createElement("li"),
+			document.createElement("li")
+		];
 
-        $.style(arr, {
-            color: "red"
-        });
+		$.style(arr, {
+			color: "red"
+		});
 
-        arr.forEach(function(item) {
-            expect(item.style.color).to.equal("red");
-        });
-    });
+		arr.forEach(function(item) {
+			expect(item.style.color).to.equal("red");
+		});
+	});
 
-    it("sets multiple styles to array", function() {
-        var arr = [
-                document.createElement("li"),
-                document.createElement("li"),
-                document.createElement("li")
-            ];
+	it("sets multiple styles to array", function() {
+		var arr = [
+			document.createElement("li"),
+			document.createElement("li"),
+			document.createElement("li")
+		];
 
-        $.style(arr, {
-            color: "red",
-            backgroundColor: "white",
-            fontSize: "20px"
-        });
+		$.style(arr, {
+			color: "red",
+			backgroundColor: "white",
+			fontSize: "20px"
+		});
 
-        arr.forEach(function(item) {
-            expect(item.style.color).to.equal("red");
-            expect(item.style.backgroundColor).to.equal("white");
-            expect(item.style.fontSize).to.equal("20px");
-        });
-    });
+		arr.forEach(function(item) {
+			expect(item.style.color).to.equal("red");
+			expect(item.style.backgroundColor).to.equal("white");
+			expect(item.style.fontSize).to.equal("20px");
+		});
+	});
 
-    it("sets simple style to array using _ operator", function() {
-        var arr = [
-                document.createElement("li"),
-                document.createElement("li"),
-                document.createElement("li")
-            ];
+	it("sets simple style to array using _ operator", function() {
+		var arr = [
+			document.createElement("li"),
+			document.createElement("li"),
+			document.createElement("li")
+		];
 
-        arr._.style({
-            color: "red"
-        });
+		arr._.style({
+			color: "red"
+		});
 
-        arr.forEach(function(item) {
-            expect(item.style.color).to.equal("red");
-        });
-    });
+		arr.forEach(function(item) {
+			expect(item.style.color).to.equal("red");
+		});
+	});
 
-    it("sets multiple styles to array using _ operator", function() {
-        var arr = [
-                document.createElement("li"),
-                document.createElement("li"),
-                document.createElement("li")
-            ];
+	it("sets multiple styles to array using _ operator", function() {
+		var arr = [
+			document.createElement("li"),
+			document.createElement("li"),
+			document.createElement("li")
+		];
 
-        arr._.style({
-            color: "red",
-            backgroundColor: "white",
-            fontSize: "20px"
-        });
+		arr._.style({
+			color: "red",
+			backgroundColor: "white",
+			fontSize: "20px"
+		});
 
-        arr.forEach(function(item) {
-            expect(item.style.color).to.equal("red");
-            expect(item.style.backgroundColor).to.equal("white");
-            expect(item.style.fontSize).to.equal("20px");
-        });
-    });
+		arr.forEach(function(item) {
+			expect(item.style.color).to.equal("red");
+			expect(item.style.backgroundColor).to.equal("white");
+			expect(item.style.fontSize).to.equal("20px");
+		});
+	});
 
-    it("allows chaining with elements", function() {
-        var el = document.createElement("li");
+	it("allows chaining with elements", function() {
+		var el = document.createElement("li");
 
-        $.style(el, {
-            color: "red"
-        })._.style({
-            backgroundColor: "white"
-        });
+		$.style(el, {
+			color: "red"
+		})._.style({
+			backgroundColor: "white"
+		});
 
-        expect(el.style.color).to.equal("red");
-        expect(el.style.backgroundColor).to.equal("white");
-    });
+		expect(el.style.color).to.equal("red");
+		expect(el.style.backgroundColor).to.equal("white");
+	});
 
-    it("allows chaining with arrays", function() {
-        var arr = [
-                document.createElement("li"),
-                document.createElement("li"),
-                document.createElement("li")
-            ];
+	it("allows chaining with arrays", function() {
+		var arr = [
+			document.createElement("li"),
+			document.createElement("li"),
+			document.createElement("li")
+		];
 
-        $.style(arr, {
-            color: "red"
-        })._.style({
-            backgroundColor: "white"
-        });
+		$.style(arr, {
+			color: "red"
+		})._.style({
+			backgroundColor: "white"
+		});
 
-        arr.forEach(function(item) {
-            expect(item.style.color).to.equal("red");
-            expect(item.style.backgroundColor).to.equal("white");
-        });
-    });
+		arr.forEach(function(item) {
+			expect(item.style.color).to.equal("red");
+			expect(item.style.backgroundColor).to.equal("white");
+		});
+	});
 });

--- a/tests/arrays/AllSpec.js
+++ b/tests/arrays/AllSpec.js
@@ -5,9 +5,9 @@ describe("$.all", function() {
     expect([]._.all).to.exist;
   });
 
-  it("returns the value of the method for each item in the array", function () {
-    var arr = ["Foo", "bar"],
-      result = $.all(arr, "toUpperCase");
+	it("returns the value of the method for each item in the array", function () {
+		var arr = ["Foo", "bar"];
+		var result = $.all(arr, "toUpperCase");
 
     expect(result[0]).to.equal("FOO");
     expect(result[1]).to.equal("BAR");
@@ -16,11 +16,12 @@ describe("$.all", function() {
 
   it("returns the original array if method returns nothing", function() {
     var Obj = function () {
-        this.method = function () {};
+      this.method = function () {};
 
-        return this;
-      }, arr = [new Obj(), new Obj(), new Obj()],
-      result = $.all(arr, "method");
+      return this;
+    };
+    var arr = [new Obj(), new Obj(), new Obj()];
+    var result = $.all(arr, "method");
 
     expect(result).to.deep.equal(arr);
   });

--- a/tests/arrays/AllSpec.js
+++ b/tests/arrays/AllSpec.js
@@ -1,66 +1,66 @@
 describe("$.all", function() {
 
-  it("exists", function() {
-    expect($.all).to.exist;
-    expect([]._.all).to.exist;
-  });
+	it("exists", function() {
+		expect($.all).to.exist;
+		expect([]._.all).to.exist;
+	});
 
 	it("returns the value of the method for each item in the array", function () {
 		var arr = ["Foo", "bar"];
 		var result = $.all(arr, "toUpperCase");
 
-    expect(result[0]).to.equal("FOO");
-    expect(result[1]).to.equal("BAR");
-    expect(result).to.deep.equal(arr._.all("toUpperCase"));
-  });
+		expect(result[0]).to.equal("FOO");
+		expect(result[1]).to.equal("BAR");
+		expect(result).to.deep.equal(arr._.all("toUpperCase"));
+	});
 
-  it("returns the original array if method returns nothing", function() {
-    var Obj = function () {
-      this.method = function () {};
+	it("returns the original array if method returns nothing", function() {
+		var Obj = function () {
+			this.method = function () {};
 
-      return this;
-    };
-    var arr = [new Obj(), new Obj(), new Obj()];
-    var result = $.all(arr, "method");
+			return this;
+		};
+		var arr = [new Obj(), new Obj(), new Obj()];
+		var result = $.all(arr, "method");
 
-    expect(result).to.deep.equal(arr);
-  });
+		expect(result).to.deep.equal(arr);
+	});
 
-  describe("the method invoked by $.all", function() {
-    var Obj, arr;
+	describe("the method invoked by $.all", function() {
+		var Obj, arr;
 
-    beforeEach(function () {
-      Obj = function() {
-        this.method = sinon.spy();
-        return this;
-      },
-      arr = [new Obj(), new Obj(), new Obj()];
-    });
+		beforeEach(function () {
+			Obj = function() {
+				this.method = sinon.spy();
+				return this;
+			},
+			arr = [new Obj(), new Obj(), new Obj()];
+		});
 
-    it("calls once for each item in the array", function() {
-      var result = $.all(arr, "method");
-      expect(result.length).to.equal(3);
+		it("calls once for each item in the array", function() {
+			var result = $.all(arr, "method");
+			expect(result.length).to.equal(3);
 
-      arr.forEach(function (item) {
-        expect(item.method.calledOnce).to.be.true;
-      });
+			arr.forEach(function (item) {
+				expect(item.method.calledOnce).to.be.true;
+			});
 
-      expect(result).to.deep.equal(arr._.all("method"));
-    });
+			expect(result).to.deep.equal(arr._.all("method"));
+		});
 
-    it("can take single params", function() {
-      var result = $.all(arr, "method", "foo");
-      arr.forEach(function (item) {
-        expect(item.method.calledWith("foo")).to.be.true;
-      });
-    });
+		it("can take single params", function() {
+			var result = $.all(arr, "method", "foo");
+			arr.forEach(function (item) {
+				expect(item.method.calledWith("foo")).to.be.true;
+			});
+		});
 
-    it("can accept multiple params", function() {
-      var result = $.all(arr, "method", ["foo", "bar"]);
-      arr.forEach(function (item) {
-        expect(item.method.calledWith(["foo", "bar"])).to.be.true;
-      });
-    });
-  });
+		it("can accept multiple params", function() {
+			var result = $.all(arr, "method", ["foo", "bar"]);
+			arr.forEach(function (item) {
+				expect(item.method.calledWith(["foo", "bar"])).to.be.true;
+			});
+		});
+	});
 
 });

--- a/tests/arrays/AllSpec.js
+++ b/tests/arrays/AllSpec.js
@@ -1,5 +1,5 @@
 describe("$.all", function() {
-  
+
   it("exists", function() {
     expect($.all).to.exist;
     expect([]._.all).to.exist;

--- a/tests/arrays/EachSpec.js
+++ b/tests/arrays/EachSpec.js
@@ -1,5 +1,5 @@
 describe("$.each", function() {
-  
+
   it("exists", function() {
     expect($.each).to.exist;
   });
@@ -15,22 +15,22 @@ describe("$.each", function() {
 
     expect(result).to.deep.equal(obj);
   });
-  
+
   it("copies properties and inherited properties from one object to new object", function () {
     var parent = function() {};
 
 	parent.prototype.func = function() {};
-	
+
 	var obj = Object.create(parent.prototype);
 	obj.prop = 1;
-	
+
     result = $.each(obj, function( prop, value ) {
       return value;
     });
-    
+
 	expect(result).to.deep.equal(obj);
-  });  
-  
+  });
+
   it("copies properties from one object to new object if callback context is original object", function () {
     var obj = {
 		prop: 1,
@@ -41,7 +41,7 @@ describe("$.each", function() {
       });
 
     expect(result).to.deep.equal(obj);
-  });  
+  });
 
   it("copies properties from object to existing object", function () {
     var obj = {
@@ -59,6 +59,6 @@ describe("$.each", function() {
 	expect(result.func).to.equal(obj.func);
 	expect(result.originalProp).to.equal(existing.originalProp);
   });
-  
+
 
 });

--- a/tests/arrays/EachSpec.js
+++ b/tests/arrays/EachSpec.js
@@ -1,64 +1,64 @@
 describe("$.each", function() {
 
-  it("exists", function() {
-    expect($.each).to.exist;
-  });
+	it("exists", function() {
+		expect($.each).to.exist;
+	});
 
-  it("copies properties from one object to new object", function () {
-    var obj = {
-		prop: 1,
-		func: function() {}
-	  },
-      result = $.each(obj, function( prop, value ) {
-        return value;
-      });
+	it("copies properties from one object to new object", function () {
+		var obj = {
+			prop: 1,
+			func: function() {}
+		},
+		result = $.each(obj, function( prop, value ) {
+			return value;
+		});
 
-    expect(result).to.deep.equal(obj);
-  });
+		expect(result).to.deep.equal(obj);
+	});
 
-  it("copies properties and inherited properties from one object to new object", function () {
-    var parent = function() {};
+	it("copies properties and inherited properties from one object to new object", function () {
+		var parent = function() {};
 
-	parent.prototype.func = function() {};
+		parent.prototype.func = function() {};
 
-	var obj = Object.create(parent.prototype);
-	obj.prop = 1;
+		var obj = Object.create(parent.prototype);
+		obj.prop = 1;
 
-    result = $.each(obj, function( prop, value ) {
-      return value;
-    });
+		result = $.each(obj, function( prop, value ) {
+			return value;
+		});
 
-	expect(result).to.deep.equal(obj);
-  });
+		expect(result).to.deep.equal(obj);
+	});
 
-  it("copies properties from one object to new object if callback context is original object", function () {
-    var obj = {
-		prop: 1,
-		func: function() {}
-	  },
-      result = $.each(obj, function(prop) {
-        return this[prop];
-      });
+	it("copies properties from one object to new object if callback context is original object", function () {
+		var obj = {
+			prop: 1,
+			func: function() {}
+		},
+		result = $.each(obj, function(prop) {
+			return this[prop];
+		});
 
-    expect(result).to.deep.equal(obj);
-  });
+		expect(result).to.deep.equal(obj);
+	});
 
-  it("copies properties from object to existing object", function () {
-    var obj = {
-		prop: 1,
-		func: function() {}
-	  },
-	  existing = {
-		originalProp: 2
-	  },
-      result = $.each(obj, function( prop, value ) {
-        return value;
-      }, existing);
+	it("copies properties from object to existing object", function () {
+		var obj = {
+			prop: 1,
+			func: function() {}
+		},
+		existing = {
+			originalProp: 2
+		},
+		result = $.each(obj, function( prop, value ) {
+			return value;
+		}, existing);
 
-    expect(result.prop).to.equal(obj.prop);
-	expect(result.func).to.equal(obj.func);
-	expect(result.originalProp).to.equal(existing.originalProp);
-  });
+		expect(result.prop).to.equal(obj.prop);
+		expect(result.func).to.equal(obj.func);
+		expect(result.originalProp).to.equal(existing.originalProp);
+	});
 
 
 });

--- a/tests/events/DelegateSpec.js
+++ b/tests/events/DelegateSpec.js
@@ -52,14 +52,14 @@ describe("$.delegate", function() {
 			});
 
 			$.delegate(subject, "click", {
-				"a": function() { 
-					spy(1, this); 
+				"a": function() {
+					spy(1, this);
 				},
-				"span": function() { 
-					spy(2, this); 
+				"span": function() {
+					spy(2, this);
 				},
-				"img": function() { 
-					spy(3, this); 
+				"img": function() {
+					spy(3, this);
 				}
 			});
 
@@ -77,14 +77,14 @@ describe("$.delegate", function() {
 			});
 
 			subject._.delegate("click", {
-				"a": function() { 
-					spy(1, this); 
+				"a": function() {
+					spy(1, this);
 				},
-				"span": function() { 
-					spy(2, this); 
+				"span": function() {
+					spy(2, this);
 				},
-				"img": function() { 
-					spy(3, this); 
+				"img": function() {
+					spy(3, this);
 				}
 			});
 
@@ -103,14 +103,14 @@ describe("$.delegate", function() {
 
 			// TODO: Make less trivial (multiple subjects)
 			[subject]._.delegate("click", {
-				"a": function() { 
-					spy(1, this); 
+				"a": function() {
+					spy(1, this);
 				},
-				"span": function() { 
-					spy(2, this); 
+				"span": function() {
+					spy(2, this);
 				},
-				"img": function() { 
-					spy(3, this); 
+				"img": function() {
+					spy(3, this);
 				}
 			});
 
@@ -135,24 +135,24 @@ describe("$.delegate", function() {
 
 			$.delegate(subject, {
 				"mousedown": {
-					"a": function() { 
-						mouseDownSpy(1, this); 
+					"a": function() {
+						mouseDownSpy(1, this);
 					},
-					"span": function() { 
-						mouseDownSpy(2, this); 
+					"span": function() {
+						mouseDownSpy(2, this);
 					},
-					"img": function() { 
-						mouseDownSpy(3, this); 
+					"img": function() {
+						mouseDownSpy(3, this);
 					}
 				},
 				"mouseup": {
-					"a": function() { 
-						mouseUpSpy(1, this); 
+					"a": function() {
+						mouseUpSpy(1, this);
 					},
 					"span": function() {
-						mouseUpSpy(2, this); 
+						mouseUpSpy(2, this);
 					},
-					"img": function() { 
+					"img": function() {
 						mouseUpSpy(3, this);
 					}
 				}

--- a/tests/events/ReadySpec.js
+++ b/tests/events/ReadySpec.js
@@ -24,11 +24,11 @@ describe("$.ready", function () {
 			done();
 		}, 1);
 	});
-	
+
 	// should fire automatically because DOM is already loaded
 	it("should fire immediately", function (done) {
 		mocDoc.readyState = "complete";
-		
+
 		$.ready(mocDoc).then(spy);
 
 		setTimeout(function () {

--- a/tests/events/UnbindSpec.js
+++ b/tests/events/UnbindSpec.js
@@ -1,156 +1,156 @@
 describe("$.unbind", function () {
 
-    helpers.fixture("events.html");
-    var spy1, spy2, spy3, subject;
+	helpers.fixture("events.html");
+	var spy1, spy2, spy3, subject;
 
-    beforeEach(function () {
-        spy1 = sinon.spy();
-        spy2 = sinon.spy();
-        spy3 = sinon.spy();
-        subject = document.querySelector("#simpleDiv");
-    });
+	beforeEach(function () {
+		spy1 = sinon.spy();
+		spy2 = sinon.spy();
+		spy3 = sinon.spy();
+		subject = document.querySelector("#simpleDiv");
+	});
 
-    it("exists", function () {
-        expect($.unbind).to.exist;
-    });
+	it("exists", function () {
+		expect($.unbind).to.exist;
+	});
 
-    it("unbinds events using namespaces", function (done) {
-        // Setup
-        subject.addEventListener("click.namespace1", spy1);
-        subject.addEventListener("click.namespace1", spy2);
-        subject.addEventListener("click.namespace2", spy3);
+	it("unbinds events using namespaces", function (done) {
+		// Setup
+		subject.addEventListener("click.namespace1", spy1);
+		subject.addEventListener("click.namespace1", spy2);
+		subject.addEventListener("click.namespace2", spy3);
 
-        // Exercise
-        $.unbind(subject, ".namespace1");
-        fireEvent(subject, "click");
+		// Exercise
+		$.unbind(subject, ".namespace1");
+		fireEvent(subject, "click");
 
-        // Verify
-        expect(spy1.notCalled).to.be.ok;
-        expect(spy2.notCalled).to.be.ok;
-        expect(spy3.calledOnce).to.be.ok;
+		// Verify
+		expect(spy1.notCalled).to.be.ok;
+		expect(spy2.notCalled).to.be.ok;
+		expect(spy3.calledOnce).to.be.ok;
 
-        done();
-    });
+		done();
+	});
 
-    it("unbinds a single event listener", function (done) {
-        // Setup
-        subject.addEventListener("click", spy1);
-        subject.addEventListener("click", spy2);
-        subject.addEventListener("change", spy3);
+	it("unbinds a single event listener", function (done) {
+		// Setup
+		subject.addEventListener("click", spy1);
+		subject.addEventListener("click", spy2);
+		subject.addEventListener("change", spy3);
 
-        // Exercise
-        $.unbind(subject, "click", spy1);
-        fireEvent(subject, "click");
-        fireEvent(subject, "change");
+		// Exercise
+		$.unbind(subject, "click", spy1);
+		fireEvent(subject, "click");
+		fireEvent(subject, "change");
 
-        // Verify
-        expect(spy1.notCalled).to.be.ok;
-        expect(spy2.calledOnce).to.be.ok;
-        expect(spy3.calledOnce).to.be.ok;
+		// Verify
+		expect(spy1.notCalled).to.be.ok;
+		expect(spy2.calledOnce).to.be.ok;
+		expect(spy3.calledOnce).to.be.ok;
 
-        done();
-    });
+		done();
+	});
 
-    it("unbinds a single event listener when passed an object", function (done) {
-        // Setup
-        subject.addEventListener("click", spy1);
-        subject.addEventListener("click", spy2);
-        subject.addEventListener("change", spy3);
+	it("unbinds a single event listener when passed an object", function (done) {
+		// Setup
+		subject.addEventListener("click", spy1);
+		subject.addEventListener("click", spy2);
+		subject.addEventListener("change", spy3);
 
-        // Exercise
-        $.unbind(subject, {click: spy1});
-        fireEvent(subject, "click");
-        fireEvent(subject, "change");
+		// Exercise
+		$.unbind(subject, {click: spy1});
+		fireEvent(subject, "click");
+		fireEvent(subject, "change");
 
-        // Verify
-        expect(spy1.notCalled).to.be.ok;
-        expect(spy2.calledOnce).to.be.ok;
-        expect(spy3.calledOnce).to.be.ok;
+		// Verify
+		expect(spy1.notCalled).to.be.ok;
+		expect(spy2.calledOnce).to.be.ok;
+		expect(spy3.calledOnce).to.be.ok;
 
-        done();
-    });
+		done();
+	});
 
-    it("unbinds listeners when only type passed", function (done) {
-        // Setup
-        subject.addEventListener("click", spy1);
-        subject.addEventListener("click", spy2);
-        subject.addEventListener("change", spy3);
+	it("unbinds listeners when only type passed", function (done) {
+		// Setup
+		subject.addEventListener("click", spy1);
+		subject.addEventListener("click", spy2);
+		subject.addEventListener("change", spy3);
 
-        // Exercise
-        $.unbind(subject, "click");
-        fireEvent(subject, "click");
-        fireEvent(subject, "change");
+		// Exercise
+		$.unbind(subject, "click");
+		fireEvent(subject, "click");
+		fireEvent(subject, "change");
 
-        // Verify
-        expect(spy1.notCalled).to.be.ok;
-        expect(spy2.notCalled).to.be.ok;
-        expect(spy3.calledOnce).to.be.ok;
+		// Verify
+		expect(spy1.notCalled).to.be.ok;
+		expect(spy2.notCalled).to.be.ok;
+		expect(spy3.calledOnce).to.be.ok;
 
-        done();
-    });
+		done();
+	});
 
-    it("unbinds multiple event listeners", function (done) {
-        // Setup
-        subject.addEventListener("click", spy1);
-        subject.addEventListener("change", spy1);
-        subject.addEventListener("click", spy2);
-        subject.addEventListener("change", spy2);
+	it("unbinds multiple event listeners", function (done) {
+		// Setup
+		subject.addEventListener("click", spy1);
+		subject.addEventListener("change", spy1);
+		subject.addEventListener("click", spy2);
+		subject.addEventListener("change", spy2);
 
-        // Exercise
-        $.unbind(subject, "click change", spy1);
-        fireEvent(subject, "click");
-        fireEvent(subject, "change");
+		// Exercise
+		$.unbind(subject, "click change", spy1);
+		fireEvent(subject, "click");
+		fireEvent(subject, "change");
 
-        // Verify
-        expect(spy1.notCalled).to.be.ok;
-        expect(spy2.calledTwice).to.be.ok;
+		// Verify
+		expect(spy1.notCalled).to.be.ok;
+		expect(spy2.calledTwice).to.be.ok;
 
-        done();
-    });
+		done();
+	});
 
-    it("unbinds multiple event listeners when passed object", function (done) {
-        // Setup
-        subject.addEventListener("click", spy1);
-        subject.addEventListener("change", spy1);
-        subject.addEventListener("click", spy2);
-        subject.addEventListener("change", spy2);
+	it("unbinds multiple event listeners when passed object", function (done) {
+		// Setup
+		subject.addEventListener("click", spy1);
+		subject.addEventListener("change", spy1);
+		subject.addEventListener("click", spy2);
+		subject.addEventListener("change", spy2);
 
-        // Exercise
-        $.unbind(subject, {"click change": spy1});
-        fireEvent(subject, "click");
-        fireEvent(subject, "change");
+		// Exercise
+		$.unbind(subject, {"click change": spy1});
+		fireEvent(subject, "click");
+		fireEvent(subject, "change");
 
-        // Verify
-        expect(spy1.notCalled).to.be.ok;
-        expect(spy2.calledTwice).to.be.ok;
+		// Verify
+		expect(spy1.notCalled).to.be.ok;
+		expect(spy2.calledTwice).to.be.ok;
 
-        done();
-    });
+		done();
+	});
 
-    it("unbinds all event listeners", function (done) {
-        // Setup
-        subject.addEventListener("click", spy1);
-        subject.addEventListener("change", spy1);
-        subject.addEventListener("click", spy2);
-        subject.addEventListener("change", spy3);
-        subject.addEventListener("click.namespace1.bar", spy2);
+	it("unbinds all event listeners", function (done) {
+		// Setup
+		subject.addEventListener("click", spy1);
+		subject.addEventListener("change", spy1);
+		subject.addEventListener("click", spy2);
+		subject.addEventListener("change", spy3);
+		subject.addEventListener("click.namespace1.bar", spy2);
 
-        // Exercise
-        $.unbind(subject);
-        fireEvent(subject, "click");
-        fireEvent(subject, "change");
+		// Exercise
+		$.unbind(subject);
+		fireEvent(subject, "click");
+		fireEvent(subject, "change");
 
-        // Verify
-        expect(spy1.notCalled).to.be.ok;
-        expect(spy2.notCalled).to.be.ok;
-        expect(spy3.notCalled).to.be.ok;
+		// Verify
+		expect(spy1.notCalled).to.be.ok;
+		expect(spy2.notCalled).to.be.ok;
+		expect(spy3.notCalled).to.be.ok;
 
-        done();
-    });
+		done();
+	});
 
-    function fireEvent(target, eventName) {
-        var event = new Event(eventName, {"bubbles": true, "cancelable": true});
-        target.dispatchEvent(event);
-    }
+	function fireEvent(target, eventName) {
+		var event = new Event(eventName, {"bubbles": true, "cancelable": true});
+		target.dispatchEvent(event);
+	}
 
 });

--- a/tests/events/UnbindSpec.js
+++ b/tests/events/UnbindSpec.js
@@ -1,19 +1,19 @@
 describe("$.unbind", function () {
-    
+
     helpers.fixture("events.html");
     var spy1, spy2, spy3, subject;
-            
+
     beforeEach(function () {
         spy1 = sinon.spy();
         spy2 = sinon.spy();
         spy3 = sinon.spy();
         subject = document.querySelector("#simpleDiv");
     });
-    
+
     it("exists", function () {
         expect($.unbind).to.exist;
     });
-    
+
     it("unbinds events using namespaces", function (done) {
         // Setup
         subject.addEventListener("click.namespace1", spy1);
@@ -31,7 +31,7 @@ describe("$.unbind", function () {
 
         done();
     });
-    
+
     it("unbinds a single event listener", function (done) {
         // Setup
         subject.addEventListener("click", spy1);
@@ -47,10 +47,10 @@ describe("$.unbind", function () {
         expect(spy1.notCalled).to.be.ok;
         expect(spy2.calledOnce).to.be.ok;
         expect(spy3.calledOnce).to.be.ok;
-        
+
         done();
     });
-    
+
     it("unbinds a single event listener when passed an object", function (done) {
         // Setup
         subject.addEventListener("click", spy1);
@@ -66,10 +66,10 @@ describe("$.unbind", function () {
         expect(spy1.notCalled).to.be.ok;
         expect(spy2.calledOnce).to.be.ok;
         expect(spy3.calledOnce).to.be.ok;
-        
+
         done();
     });
-    
+
     it("unbinds listeners when only type passed", function (done) {
         // Setup
         subject.addEventListener("click", spy1);
@@ -85,10 +85,10 @@ describe("$.unbind", function () {
         expect(spy1.notCalled).to.be.ok;
         expect(spy2.notCalled).to.be.ok;
         expect(spy3.calledOnce).to.be.ok;
-        
+
         done();
     });
-    
+
     it("unbinds multiple event listeners", function (done) {
         // Setup
         subject.addEventListener("click", spy1);
@@ -104,10 +104,10 @@ describe("$.unbind", function () {
         // Verify
         expect(spy1.notCalled).to.be.ok;
         expect(spy2.calledTwice).to.be.ok;
-        
+
         done();
     });
-    
+
     it("unbinds multiple event listeners when passed object", function (done) {
         // Setup
         subject.addEventListener("click", spy1);
@@ -125,7 +125,7 @@ describe("$.unbind", function () {
         expect(spy2.calledTwice).to.be.ok;
 
         done();
-    });    
+    });
 
     it("unbinds all event listeners", function (done) {
         // Setup
@@ -144,10 +144,10 @@ describe("$.unbind", function () {
         expect(spy1.notCalled).to.be.ok;
         expect(spy2.notCalled).to.be.ok;
         expect(spy3.notCalled).to.be.ok;
-        
+
         done();
     });
-    
+
     function fireEvent(target, eventName) {
         var event = new Event(eventName, {"bubbles": true, "cancelable": true});
         target.dispatchEvent(event);

--- a/tests/objects/AddSpec.js
+++ b/tests/objects/AddSpec.js
@@ -1,7 +1,7 @@
 describe("$.add", function () {
 
 	helpers.fixture("core.html");
-	
+
 	var spy;
 
 	beforeEach(function() {
@@ -66,25 +66,25 @@ describe("$.add", function () {
 		});
 
 		it("overwrites functions by default", function () {
-			$.add("overwrite", function() { 
-				return "foo"; 
+			$.add("overwrite", function() {
+				return "foo";
 			});
 			expect(document._.overwrite()).to.equal("foo");
-			
-			$.add("overwrite", function() { 
-				return "bar"; 
+
+			$.add("overwrite", function() {
+				return "bar";
 			});
 			expect(document._.overwrite()).to.equal("bar");
 		});
 
 		it("refuses to overwrite functions when told", function () {
-			$.add("overwrite", function() { 
-				return "foo"; 
+			$.add("overwrite", function() {
+				return "foo";
 			});
 			expect(document._.overwrite()).to.equal("foo");
 
-			$.add({overwrite: function() { 
-				return "bar"; 
+			$.add({overwrite: function() {
+				return "bar";
 			}}, null, true);
 			expect(document._.overwrite()).to.equal("foo");
 		});

--- a/tests/objects/AddSpec.js
+++ b/tests/objects/AddSpec.js
@@ -33,8 +33,8 @@ describe("$.add", function () {
 
 		it("accepts multiple functions by passing an object", function () {
 			var methods = {
-					baz: function () {},
-					baz2: function () {}
+				baz: function () {},
+				baz2: function () {}
 			};
 
 			$.add(methods);

--- a/tests/objects/ExtendSpec.js
+++ b/tests/objects/ExtendSpec.js
@@ -16,12 +16,12 @@ describe("$.extend", function() {
 			hobby: "Fishing",
 			food: "pasta"
 		};
-	        orgChild = {
-				id: 30,
-				name: "Jim",
-				hobby: "Biking",
-				food: "pizza"
-			};
+		orgChild = {
+			id: 30,
+			name: "Jim",
+			hobby: "Biking",
+			food: "pizza"
+		};
 	});
 
 	it("copies properties from parent to child", function() {
@@ -48,13 +48,13 @@ describe("$.extend", function() {
 	});
 
 	it("String whitelist only copies that property", function() {
-	        var newParent = Object.create(parent);
-	        newParent.ownProperty = "Only property that should be added to child";
-	        $.extend(child, newParent, "ownProperty");
+		var newParent = Object.create(parent);
+		newParent.ownProperty = "Only property that should be added to child";
+		$.extend(child, newParent, "ownProperty");
 
-	        expect(child.food).to.not.equal(newParent.food);
-	        expect(child.hobby).to.equal(orgChild.hobby);
-	        expect(child.ownProperty).to.equal(newParent.ownProperty);
+		expect(child.food).to.not.equal(newParent.food);
+		expect(child.hobby).to.equal(orgChild.hobby);
+		expect(child.ownProperty).to.equal(newParent.ownProperty);
 	});
 
 	it("takes a function to filter the properties", function() {

--- a/tests/objects/FetchSpec.js
+++ b/tests/objects/FetchSpec.js
@@ -1,7 +1,7 @@
 describe("$.fetch", function() {
-  var server,
-      data = "foo=b%20ar&baz=yolo",
-      headers = {foo: "bar", "Content-type": "yadda;charset=utf-8"};
+  var server;
+  var data = "foo=b%20ar&baz=yolo";
+  var headers = {foo: "bar", "Content-type": "yadda;charset=utf-8"};
 
   before(function() {
     server = sinon.fakeServer.create();

--- a/tests/objects/FetchSpec.js
+++ b/tests/objects/FetchSpec.js
@@ -1,97 +1,97 @@
 describe("$.fetch", function() {
-  var server;
-  var data = "foo=b%20ar&baz=yolo";
-  var headers = {foo: "bar", "Content-type": "yadda;charset=utf-8"};
+	var server;
+	var data = "foo=b%20ar&baz=yolo";
+	var headers = {foo: "bar", "Content-type": "yadda;charset=utf-8"};
 
-  before(function() {
-    server = sinon.fakeServer.create();
-    server.respondWith("POST", "/json", function (request) {
-      request.respond(200, request.requestHeaders, request.requestBody);
-    });
+	before(function() {
+		server = sinon.fakeServer.create();
+		server.respondWith("POST", "/json", function (request) {
+			request.respond(200, request.requestHeaders, request.requestBody);
+		});
 
-    server.respondWith("GET", /\/json\??(.*)/, function (request, query) {
-      request.respond(200, request.requestHeaders, query);
-    });
-  });
+		server.respondWith("GET", /\/json\??(.*)/, function (request, query) {
+			request.respond(200, request.requestHeaders, query);
+		});
+	});
 
-  after(function () {
-    server.restore();
-  });
+	after(function () {
+		server.restore();
+	});
 
-  it("exists", function () {
-    expect($.fetch).to.exist;
-    expect(Bliss.fetch).to.exist;
-  });
+	it("exists", function () {
+		expect($.fetch).to.exist;
+		expect(Bliss.fetch).to.exist;
+	});
 
-  describe("POST", function () {
-    it("POSTs data (URLencoded string)", function () {
-      return verifyResponseBody("POST", data, "foo=b ar&baz=yolo");
-    });
+	describe("POST", function () {
+		it("POSTs data (URLencoded string)", function () {
+			return verifyResponseBody("POST", data, "foo=b ar&baz=yolo");
+		});
 
-    it("handles method type in any case", function () {
-      return verifyResponseBody("post", data, "foo=b ar&baz=yolo");
-    });
+		it("handles method type in any case", function () {
+			return verifyResponseBody("post", data, "foo=b ar&baz=yolo");
+		});
 
-    it("sets provided headers", function () {
-      return verifyResponseHeaders("POST", headers, headers);
-    });
+		it("sets provided headers", function () {
+			return verifyResponseHeaders("POST", headers, headers);
+		});
 
-    it("sets Content-type header for POST if not provided", function () {
-      return verifyResponseHeaders("POST", {}, {
-        "Content-type": "application/x-www-form-urlencoded;charset=utf-8"
-      });
-    });
+		it("sets Content-type header for POST if not provided", function () {
+			return verifyResponseHeaders("POST", {}, {
+				"Content-type": "application/x-www-form-urlencoded;charset=utf-8"
+			});
+		});
 
-    it("catch 404", function (done) {
-      handleJSON("/bad", "POST", "").catch(function () {
-	       done();
-       });
-    });
-  });
+		it("catch 404", function (done) {
+			handleJSON("/bad", "POST", "").catch(function () {
+				done();
+			});
+		});
+	});
 
-  describe("GET", function () {
-    it("GETs data (URLencoded string)", function () {
-      return verifyResponseBody("GET", data, "foo=b ar&baz=yolo");
-    });
+	describe("GET", function () {
+		it("GETs data (URLencoded string)", function () {
+			return verifyResponseBody("GET", data, "foo=b ar&baz=yolo");
+		});
 
-    it("handles method type in any case", function () {
-      return verifyResponseBody("get", data, "foo=b ar&baz=yolo");
-    });
+		it("handles method type in any case", function () {
+			return verifyResponseBody("get", data, "foo=b ar&baz=yolo");
+		});
 
-    it("sets provided headers", function () {
-      return verifyResponseHeaders("GET", headers, headers);
-    });
+		it("sets provided headers", function () {
+			return verifyResponseHeaders("GET", headers, headers);
+		});
 
-    it("catch 404", function (done) {
-      handleJSON("/bad", "GET", "").catch(function () {
-	       done();
-       });
-    });
-  });
+		it("catch 404", function (done) {
+			handleJSON("/bad", "GET", "").catch(function () {
+				done();
+			});
+		});
+	});
 
-  function handleJSON(url, method, data, headers) {
-    var then = $.fetch(url, {
-      method: method,
-      data: data,
-      headers: headers || {}
-    });
+	function handleJSON(url, method, data, headers) {
+		var then = $.fetch(url, {
+			method: method,
+			data: data,
+			headers: headers || {}
+		});
 
-    server.respond();
+		server.respond();
 
-    return then;
-  }
+		return then;
+	}
 
-  function verifyResponseBody(method, data, expected) {
-    var promise = handleJSON("/json", method, data);
-    return promise.then(function (response) {
-      expect(response.response).to.equal(encodeURI(expected));
-    });
-  }
+	function verifyResponseBody(method, data, expected) {
+		var promise = handleJSON("/json", method, data);
+		return promise.then(function (response) {
+			expect(response.response).to.equal(encodeURI(expected));
+		});
+	}
 
-  function verifyResponseHeaders(method, headers, expected) {
-    var promise = handleJSON("/json", method, "", headers);
-    return promise.then(function (response) {
-      expect(response.responseHeaders).to.deep.equal(expected);
-    });
-  }
+	function verifyResponseHeaders(method, headers, expected) {
+		var promise = handleJSON("/json", method, "", headers);
+		return promise.then(function (response) {
+			expect(response.responseHeaders).to.deep.equal(expected);
+		});
+	}
 });

--- a/tests/objects/HooksSpec.js
+++ b/tests/objects/HooksSpec.js
@@ -1,30 +1,30 @@
 describe("$.hooks", function () {
 
-  it("exists", function () {
-    expect($.hooks).to.exist;
-    expect($.hooks.add).to.exist;
-    expect($.hooks.run).to.exist;
-  });
+	it("exists", function () {
+		expect($.hooks).to.exist;
+		expect($.hooks.add).to.exist;
+		expect($.hooks.run).to.exist;
+	});
 
-  it("adds a hook by providing a name and callback", function () {
-    var spy = sinon.spy();
+	it("adds a hook by providing a name and callback", function () {
+		var spy = sinon.spy();
 
-    $.hooks.add("hook1", spy);
-    $.hooks.run("hook1");
+		$.hooks.add("hook1", spy);
+		$.hooks.run("hook1");
 
-    expect(spy.callCount).to.equal(1);
-  });
+		expect(spy.callCount).to.equal(1);
+	});
 
-  it("provides an environment variable while running a hook", function (done) {
-    var foo = {
-      foo: "bar"
-    };
+	it("provides an environment variable while running a hook", function (done) {
+		var foo = {
+			foo: "bar"
+		};
 
-    $.hooks.add("hook2", function (env) {
-      expect(env).to.deep.equal(foo);
-      done();
-    });
+		$.hooks.add("hook2", function (env) {
+			expect(env).to.deep.equal(foo);
+			done();
+		});
 
-    $.hooks.run("hook2", foo);
-  });
+		$.hooks.run("hook2", foo);
+	});
 });

--- a/tests/objects/LazySpec.js
+++ b/tests/objects/LazySpec.js
@@ -16,8 +16,8 @@ describe("$.lazy", function() {
 
 	describe("returns type of object passed, but with function", function() {
 		it("returns the same type of instantiated class passed", function() {
-			var spy = sinon.spy(),
-				obj = $.lazy(new TestClass(), "pets", spy);
+			var spy = sinon.spy();
+			var obj = $.lazy(new TestClass(), "pets", spy);
 
 			expect(obj instanceof TestClass).to.be.true;
 			expect(obj.pets).to.be.defined;
@@ -25,8 +25,8 @@ describe("$.lazy", function() {
 		});
 
 		it("returns the same Object passed", function() {
-			var spy = sinon.spy(),
-				obj = $.lazy(testObj, "pets", spy);
+			var spy = sinon.spy();
+			var obj = $.lazy(testObj, "pets", spy);
 
 			expect(obj.animals).to.deep.equal(["kittens"]);
 			expect(obj.pets).to.be.defined;
@@ -34,8 +34,8 @@ describe("$.lazy", function() {
 		});
 
 		it("deletes the property if exists when getter is called", function() {
-			var stub = sinon.stub().returns("no bar"),
-				obj = $.lazy({foo: "bar"}, "foo", stub);
+			var stub = sinon.stub().returns("no bar");
+			var obj = $.lazy({foo: "bar"}, "foo", stub);
 
 			obj.foo;
 			expect(obj.foo).to.not.equal("bar");
@@ -45,8 +45,8 @@ describe("$.lazy", function() {
 
 		it("overwrites a prototype property if exists", function() {
 			var klass = $.extend(TestClass, {pet: "dog"});
-			var stub = sinon.stub().returns("bird"),
-				result = $.lazy((new klass()), "pet", stub);
+			var stub = sinon.stub().returns("bird");
+			var result = $.lazy((new klass()), "pet", stub);
 
 			expect(result.pet).to.equal("bird");
 		});
@@ -55,9 +55,9 @@ describe("$.lazy", function() {
 			TestClass.prototype.pet = "dog";
 			TestClass.prototype.food = "pizza";
 
-			var petStub = sinon.stub().returns("snake"),
-				foodStub = sinon.stub().returns("pie"),
-				inst = $.lazy((new TestClass()), {pet: petStub, food: foodStub});
+			var petStub = sinon.stub().returns("snake");
+			var foodStub = sinon.stub().returns("pie");
+			var inst = $.lazy((new TestClass()), {pet: petStub, food: foodStub});
 
 			expect(inst.pet).to.equal("snake");
 			expect(inst.food).to.equal("pie");
@@ -66,8 +66,8 @@ describe("$.lazy", function() {
 
 	describe("the method defined via $.lazy", function() {
 		it("will always return the first value returned", function() {
-			var stub = sinon.stub().returns(testObj.animals.slice(0)),
-				obj = $.lazy(testObj, "pets", stub);
+			var stub = sinon.stub().returns(testObj.animals.slice(0));
+			var obj = $.lazy(testObj, "pets", stub);
 
 			expect(obj.pets).to.deep.equal(obj.animals);
 			obj.animals.push("dogs");
@@ -77,8 +77,8 @@ describe("$.lazy", function() {
 		});
 
 		it("will return updated values if returning an obj property", function() {
-			var stub = sinon.stub().returns(testObj.animals),
-				obj = $.lazy(testObj, "pets", stub);
+			var stub = sinon.stub().returns(testObj.animals);
+			var obj = $.lazy(testObj, "pets", stub);
 
 			expect(obj.pets).to.deep.equal(obj.animals);
 			obj.animals.push("dogs");
@@ -87,9 +87,9 @@ describe("$.lazy", function() {
 		});
 
 		it("can take an object as the property parameter", function() {
-			var spy1 = sinon.spy(),
-				spy2 = sinon.spy(),
-				obj = $.lazy(testObj, {cats: spy1, dogs: spy2});
+			var spy1 = sinon.spy();
+			var spy2 = sinon.spy();
+			var obj = $.lazy(testObj, {cats: spy1, dogs: spy2});
 
 			expect(obj.cats).to.be.defined;
 			expect(obj.dogs).to.be.defined;

--- a/tests/objects/LazySpec.js
+++ b/tests/objects/LazySpec.js
@@ -3,13 +3,13 @@ describe("$.lazy", function() {
 	var TestClass, testObj;
 
 	beforeEach(function() {
-		TestClass = function () { 
-			return this; 
+		TestClass = function () {
+			return this;
 		};
 
 		testObj = {animals: ["kittens"]};
-	});	
-	
+	});
+
 	it("exists", function() {
 		expect($.lazy).to.exist;
 	});
@@ -71,7 +71,7 @@ describe("$.lazy", function() {
 
 			expect(obj.pets).to.deep.equal(obj.animals);
 			obj.animals.push("dogs");
-			// still only one item returned 
+			// still only one item returned
 			expect(obj.pets.length).to.equal(1);
 			expect(stub.calledOnce).to.be.true;
 		});
@@ -85,15 +85,15 @@ describe("$.lazy", function() {
 			expect(obj.pets).to.deep.equal(obj.animals);
 			expect(stub.calledOnce).to.be.true;
 		});
-	
+
 		it("can take an object as the property parameter", function() {
-			var spy1 = sinon.spy(), 
+			var spy1 = sinon.spy(),
 				spy2 = sinon.spy(),
 				obj = $.lazy(testObj, {cats: spy1, dogs: spy2});
 
 			expect(obj.cats).to.be.defined;
 			expect(obj.dogs).to.be.defined;
-			
+
 			obj.cats;
 			obj.cats;
 			obj.dogs;

--- a/tests/objects/LiveSpec.js
+++ b/tests/objects/LiveSpec.js
@@ -6,7 +6,7 @@ describe("$.live", function () {
 		setSpy = sinon.spy();
 		getSpy = sinon.spy();
 	});
-	
+
 	it("should exist", function () {
 		expect($.live).to.be.defined;
 	});
@@ -18,7 +18,7 @@ describe("$.live", function () {
 
 	describe("getters and setters", function () {
 
-		it("should define getter and call custom function", function () {			
+		it("should define getter and call custom function", function () {
 			var getSpy = sinon.spy(),
 				obj = $.live({}, "pet", {
 					get: function (value) {

--- a/tests/objects/LiveSpec.js
+++ b/tests/objects/LiveSpec.js
@@ -19,17 +19,17 @@ describe("$.live", function () {
 	describe("getters and setters", function () {
 
 		it("should define getter and call custom function", function () {
-			var getSpy = sinon.spy(),
-				obj = $.live({}, "pet", {
-					get: function (value) {
-						getSpy();
-						return value + "--suffix";
-					},
-					set: function (value) {
-						setSpy();
-						return value.trim();
-					}
-				});
+			var getSpy = sinon.spy();
+			var obj = $.live({}, "pet", {
+				get: function (value) {
+					getSpy();
+					return value + "--suffix";
+				},
+				set: function (value) {
+					setSpy();
+					return value.trim();
+				}
+			});
 
 			obj.pet = " cat   ";
 			expect(setSpy.callCount).to.equal(1);

--- a/tests/objects/OverloadSpec.js
+++ b/tests/objects/OverloadSpec.js
@@ -31,7 +31,7 @@ describe("$.overload", function() {
 			spy = sinon.spy();
 			funct = $.overload(spy, 1);
 		});
-		
+
 		it("can take a nested object", function() {
 			funct("before", {key: {}}, "after");
 			expect(spy.args[0]).to.deep.equal(["before", "key", {}, "after"]);

--- a/tests/objects/ValueSpec.js
+++ b/tests/objects/ValueSpec.js
@@ -1,11 +1,11 @@
 describe("$.value", function() {
 
 	it("exists", function () {
-	    expect($.value).to.exist;
+		expect($.value).to.exist;
 	});
 
 	it("not throw", function() {
-	    expect($.value).not.to.throw(Error);
+		expect($.value).not.to.throw(Error);
 	});
 
 	it("returns null if object is null", function() {


### PR DESCRIPTION
A lot of existing code breaks the editorconfig settings (especially in the tests), which makes it hard for contributors using editorconfig integrated editors/IDEs to change something small without also changing formatting for the whole file.

This PR does:
* Add eslint-rule "no-trailing-spaces" (it's already an editorconfig-setting, but not enforced in eslint).
* Removes trailing spaces and converts all indentation to tabs in bliss source files (bliss._.js and bliss.shy.js) and tests

It doesn't:
* Add any eslint-rule for indentation (bliss.shy.js and bliss._.js aren't correctly indented and this looks like it's possibly intentional)
* Format other files such as gulpfile.js, index.js, style/prism.js or transform.js that are not in `files` in karma.conf.js (and hence not tested)