### PR TITLE
Only set content-type to urlencoded when data is string or URLSearchParams (#208)

### DIFF
--- a/bliss.js
+++ b/bliss.js
@@ -368,11 +368,12 @@ extend($, {
 			}
 		}
 
+		var dataIsParamLike = ["string", "urlsearchparams"].indexOf($.type(env.data)) !== -1;
 		var headerKeys = Object.keys(env.headers).map(function(key) {
 			return key.toLowerCase();
 		});
 
-		if (env.method !== "GET" && headerKeys.indexOf("content-type") === -1) {
+		if (env.method !== "GET" && dataIsParamLike && headerKeys.indexOf("content-type") === -1) {
 			env.xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
 		}
 

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -368,11 +368,12 @@ extend($, {
 			}
 		}
 
+		var dataIsParamLike = ["string", "urlsearchparams"].indexOf($.type(env.data)) !== -1;
 		var headerKeys = Object.keys(env.headers).map(function(key) {
 			return key.toLowerCase();
 		});
 
-		if (env.method !== "GET" && headerKeys.indexOf("content-type") === -1) {
+		if (env.method !== "GET" && dataIsParamLike && headerKeys.indexOf("content-type") === -1) {
 			env.xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
 		}
 

--- a/tests/objects/FetchSpec.js
+++ b/tests/objects/FetchSpec.js
@@ -33,11 +33,11 @@ describe("$.fetch", function() {
 		});
 
 		it("sets provided headers", function () {
-			return verifyResponseHeaders("POST", headers, headers);
+			return verifyResponseHeaders("POST", "", headers, headers);
 		});
 
-		it("sets Content-type header for POST if not provided", function () {
-			return verifyResponseHeaders("POST", {}, {
+		it("sets Content-type header for POST if not provided for text data", function () {
+			return verifyResponseHeaders("POST", data, {}, {
 				"Content-type": "application/x-www-form-urlencoded;charset=utf-8"
 			});
 		});
@@ -59,7 +59,7 @@ describe("$.fetch", function() {
 		});
 
 		it("sets provided headers", function () {
-			return verifyResponseHeaders("GET", headers, headers);
+			return verifyResponseHeaders("GET", "", headers, headers);
 		});
 
 		it("catch 404", function (done) {
@@ -88,8 +88,8 @@ describe("$.fetch", function() {
 		});
 	}
 
-	function verifyResponseHeaders(method, headers, expected) {
-		var promise = handleJSON("/json", method, "", headers);
+	function verifyResponseHeaders(method, data, headers, expected) {
+		var promise = handleJSON("/json", method, data, headers);
 		return promise.then(function (response) {
 			expect(response.responseHeaders).to.deep.equal(expected);
 		});


### PR DESCRIPTION
As per discussion in #208.

Testing coverage is very limited (changes are semantical more than functional). This is due to sinon.js mock XHR server only supporting strings ([This is still the case in the newest version](http://sinonjs.org/releases/v4.1.2/fake-xhr-and-server/#string-requestrequestbody)). In other words this PR addresses #208, but not #200. I suggest we leave #200 open, hoping someone else has an idea of how to deal with it. The tests still work (and also would have if I hadn't changed them). They're just lacking coverage.