### PR TITLE
Linting: Force splitting variable declaration for initialized vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,9 @@
         "no-lonely-if": 1,
         "no-mixed-spaces-and-tabs": [1, "smart-tabs"],
         "no-trailing-spaces": 1,
+        "one-var": [1, {
+            "initialized": "never"
+        }],
         "padding-line-between-statements": [1,
             {
                 "blankLine": "always",

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -11,7 +11,8 @@ function overload(callback, start, end) {
 				return callback.apply(this, arguments);
 			}
 
-			var obj = arguments[start], ret;
+			var obj = arguments[start];
+			var ret;
 
 			for (var key in obj) {
 				var args = Array.prototype.slice.call(arguments);

--- a/tests/arrays/EachSpec.js
+++ b/tests/arrays/EachSpec.js
@@ -8,8 +8,8 @@ describe("$.each", function() {
 		var obj = {
 			prop: 1,
 			func: function() {}
-		},
-		result = $.each(obj, function( prop, value ) {
+		};
+		var result = $.each(obj, function( prop, value ) {
 			return value;
 		});
 
@@ -35,8 +35,8 @@ describe("$.each", function() {
 		var obj = {
 			prop: 1,
 			func: function() {}
-		},
-		result = $.each(obj, function(prop) {
+		};
+		var result = $.each(obj, function(prop) {
 			return this[prop];
 		});
 
@@ -47,11 +47,11 @@ describe("$.each", function() {
 		var obj = {
 			prop: 1,
 			func: function() {}
-		},
-		existing = {
+		};
+		var existing = {
 			originalProp: 2
-		},
-		result = $.each(obj, function( prop, value ) {
+		};
+		var result = $.each(obj, function( prop, value ) {
 			return value;
 		}, existing);
 


### PR DESCRIPTION
Eslint will now warn if declaring multiple variables in the same statement, except if all of them are uninitialized. For example, this is still valid:

`var testContainer, para0, para1, para2;`

(There are a lot of these in the test specs and splitting them up isn't necessarily better imo)