### PR TITLE
Don't force blank lines after block-like statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,10 +27,6 @@
         "padding-line-between-statements": [1,
             {
                 "blankLine": "always",
-                "prev": "block-like",
-                "next": "*"
-            }, {
-                "blankLine": "always",
                 "prev": "*",
                 "next": "block-like"
             }, {


### PR DESCRIPTION
Don't force blank lines after block-like statements, as per discussion in https://github.com/LeaVerou/bliss/pull/209#issuecomment-343298129