### PR TITLE
remove all listeners unconditionally and fixed [#221]

### DIFF
--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -643,8 +643,8 @@ $.Element.prototype = {
 					for (var i=0, l; l=listeners[ltype][i]; i++) {
 						if ((!className || className === l.className)
 							&& (!options.callback || options.callback === l.callback)
-							&& (!!options.capture == !!l.capture) || 
-						    		!type && !options.callback && undefined === options.capture) 
+							&& (!!options.capture == !!l.capture || 
+						    		!type && !options.callback && undefined === options.capture)
 						   ) {
 								listeners[ltype].splice(i, 1);
 								$.original.removeEventListener.call(this, ltype, l.callback, l.capture);

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -628,11 +628,11 @@ $.Element.prototype = {
 				type = type[0];
 			}
 
-			if (type && options.callback) {
-				return $.original.removeEventListener.call(this, type, options.callback, options.capture);
-			}
-
+			//if listeners exist, always go through listeners to clean up
 			if (!listeners) {
+				if (type && options.callback) {
+					return $.original.removeEventListener.call(this, type, options.callback, options.capture);
+				}
 				return;
 			}
 

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -643,7 +643,7 @@ $.Element.prototype = {
 					for (var i=0, l; l=listeners[ltype][i]; i++) {
 						if ((!className || className === l.className)
 							&& (!options.callback || options.callback === l.callback)
-							&& (!!options.capture == !!l.capture)) {
+							&& (!!options.capture == !!l.capture) || !type && !options.callback ) {
 								listeners[ltype].splice(i, 1);
 								$.original.removeEventListener.call(this, ltype, l.callback, l.capture);
 								i--;

--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -643,7 +643,9 @@ $.Element.prototype = {
 					for (var i=0, l; l=listeners[ltype][i]; i++) {
 						if ((!className || className === l.className)
 							&& (!options.callback || options.callback === l.callback)
-							&& (!!options.capture == !!l.capture) || !type && !options.callback ) {
+							&& (!!options.capture == !!l.capture) || 
+						    		!type && !options.callback && undefined === options.capture) 
+						   ) {
 								listeners[ltype].splice(i, 1);
 								$.original.removeEventListener.call(this, ltype, l.callback, l.capture);
 								i--;

--- a/docs.html
+++ b/docs.html
@@ -907,13 +907,14 @@ document.body._.unbind("click");
 document.body._.unbind(); // unbind ALL events
 // Clicking on the body now does nothing
 $.unbind(elem)
-// Removing all listeners added using $.bind method, regardless of event capture setting
+// Removing all listeners from elem, regardless of event capture setting. 
+// If using Bliss Shy, $.unbind only works for the listeners added using $.bind method
 $.unbind(elem, '', false)
 $.unbind(elem, undefined, false)
-// Removing all listeners added to elem using $.bind method, with capture option set to false (the default in most browsers)
+// Removing all listeners from elem, with capture option set to false (the default in most browsers)
 $.unbind(elem, '', true)
 $.unbind(elem, undefined, true)
-// Removing all listeners added to elem using $.bind method, with capture option set to true explicitly
+// Removing all listeners from elem, with capture option set to true explicitly
 </code></pre>
 
 		<ul class="notes">

--- a/docs.html
+++ b/docs.html
@@ -910,10 +910,8 @@ $.unbind(elem)
 // Removing all listeners from elem, regardless of event capture setting. 
 // If using Bliss Shy, $.unbind only works for the listeners added using $.bind method
 $.unbind(elem, '', false)
-$.unbind(elem, undefined, false)
 // Removing all listeners from elem, with capture option set to false (the default in most browsers)
 $.unbind(elem, '', true)
-$.unbind(elem, undefined, true)
 // Removing all listeners from elem, with capture option set to true explicitly
 </code></pre>
 

--- a/docs.html
+++ b/docs.html
@@ -886,7 +886,9 @@ Promise.all($$("div")._.transition({
 			<dd>The event type. You can include multiple event types by space-separating them.
 				<strong>If using Bliss Full</strong>:
 				You can also unbind by class (e.g. <code>click.foo</code> or even just <code>.foo</code> to unbind all events with that class).
-				You can also unbind all listeners on the element, by not providing <strong>any</strong> arguments.
+				You can also unbind all listeners on the element, by not providing <strong>any</strong> arguments. This will remove all listeners with capture option set to either true or false.  
+				This works for Bliss Shy and anonymous functions too, if the listeners were added using Bliss bind method. Bliss (both Full and Shy) keeps track of anonymous functions so these listeners may be removed.
+
 			</dd>
 
 			<dt class="function">callback</dt>

--- a/docs.html
+++ b/docs.html
@@ -887,7 +887,7 @@ Promise.all($$("div")._.transition({
 				<strong>If using Bliss Full</strong>:
 				You can also unbind by class (e.g. <code>click.foo</code> or even just <code>.foo</code> to unbind all events with that class).
 				You can also unbind all listeners on the element, by not providing <strong>any</strong> arguments. This will remove all listeners with capture option set to either true or false.  
-				This works for Bliss Shy and anonymous functions too, if the listeners were added using Bliss bind method. Bliss (both Full and Shy) keeps track of anonymous functions so these listeners may be removed.
+				This works for Bliss Shy and anonymous functions too, if the listeners were added using Bliss bind method. Bliss (both Full and Shy) keeps track of anonymous functions so these listeners may be removed later.
 
 			</dd>
 
@@ -906,6 +906,14 @@ document.body._.unbind("click");
 // Clicking on the body now prints only bar mousedown
 document.body._.unbind(); // unbind ALL events
 // Clicking on the body now does nothing
+$.unbind(elem)
+// Removing all listeners added using $.bind method, regardless of event capture setting
+$.unbind(elem, '', false)
+$.unbind(elem, undefined, false)
+// Removing all listeners added to elem using $.bind method, with capture option set to false (the default in most browsers)
+$.unbind(elem, '', true)
+$.unbind(elem, undefined, true)
+// Removing all listeners added to elem using $.bind method, with capture option set to true explicitly
 </code></pre>
 
 		<ul class="notes">


### PR DESCRIPTION
if neither event type nor callback has been given, remove all stored listeners from an element regardless of capture value setting. This avoid iterating through the arrays twice for cleaning up, once for capture=true and once for capture=false.
