### PR TITLE
add config option to use data structure Map instead of WeakMap

### DIFF
--- a/bliss.shy.js
+++ b/bliss.shy.js
@@ -102,7 +102,7 @@ extend($, {
 	type: type,
 
 	property: $.property || "_",
-	listeners: self.WeakMap? new WeakMap() : new Map(),
+	listeners: (self.WeakMap && false !== $.useWeakMap)? new WeakMap() : new Map(),
 
 	original: {
 		addEventListener: (self.EventTarget || Node).prototype.addEventListener,
@@ -643,7 +643,7 @@ $.Element.prototype = {
 					for (var i=0, l; l=listeners[ltype][i]; i++) {
 						if ((!className || className === l.className)
 							&& (!options.callback || options.callback === l.callback)
-							&& (!!options.capture == !!l.capture || 
+							&& (!!options.capture == !!l.capture ||
 						    		!type && !options.callback && undefined === options.capture)
 						   ) {
 								listeners[ltype].splice(i, 1);

--- a/docs.html
+++ b/docs.html
@@ -886,7 +886,7 @@ Promise.all($$("div")._.transition({
 			<dd>The event type. You can include multiple event types by space-separating them.
 				<strong>If using Bliss Full</strong>:
 				You can also unbind by class (e.g. <code>click.foo</code> or even just <code>.foo</code> to unbind all events with that class).
-				You can also unbind all listeners on the element, by not providing <strong>any</strong> arguments. This will remove all listeners with capture option set to either true or false.  
+				You can also unbind all listeners on the element, by not providing <strong>any</strong> arguments. This will remove all listeners with capture option set to either true or false.
 				This works for Bliss Shy and anonymous functions too, if the listeners were added using Bliss bind method. Bliss (both Full and Shy) keeps track of anonymous functions so these listeners may be removed later.
 
 			</dd>
@@ -907,7 +907,7 @@ document.body._.unbind("click");
 document.body._.unbind(); // unbind ALL events
 // Clicking on the body now does nothing
 $.unbind(elem)
-// Removing all listeners from elem, regardless of event capture setting. 
+// Removing all listeners from elem, regardless of event capture setting.
 // If using Bliss Shy, $.unbind only works for the listeners added using $.bind method
 $.unbind(elem, '', false)
 // Removing all listeners from elem, with capture option set to false (the default in most browsers)
@@ -1522,7 +1522,12 @@ $.hooks.add("fetch-args", function(env) {
 	<pre><code class="language-markup">&lt;script>self.Bliss = { property: "yolo" };&lt;/script>
 &lt;script src="bliss.js">&lt;/script></code></pre>
 
-	<p>As of now, these are the only configuration options, but there might be more in the future.</p>
+<p>Bliss uses a <code>WeakMap</code> or <code>Map</code> to track elements and registered event handlers under the property <code>listeners</code>. If a browser supports <code>WeakMap</code>, Bliss uses <code>WeakMap</code> by default, and falls back to <code>Map</code>. <code>WeakMap</code> does not contribute to the references. If there is no other reference to an element, the element can still be garbage collected. <code>WeakMap</code> is not iterable by design. If you want to manage these elements and event handlers more precisely, you can configure Bliss to always use a <code>Map</code> by setting the following option. You can then loop through <code>Bliss.listeners</code> with your logic.
+
+<pre><code class="language-markup">&lt;script>self.Bliss = { useWeakMap: false };&lt;/script>
+&lt;script src="bliss.js">&lt;/script></code></pre>
+
+<p>As of now, these are the only configuration options, but there might be more in the future.</p>
 </section>
 
 <!-- HTML transformations! Like the idea? Check out transform.js and let me know if I should release it :) -->


### PR DESCRIPTION
As per mavoweb/mavo issue #417, we need to loop through elements, unbind events and manually delete elements in order to break circular reference. A data structure of Map allows us to do that. 

For backward compatibility, Bliss still defaults to WeakMap if this option is not set. Please consider.