### PR TITLE
Fix table of contents not showing

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ $$("section h1").forEach(function(h1) {
 	}
 });
 
-if (/\/docs\.html$/.test(location.pathname)) {
+if (/\/docs(?:\.html)?$/.test(location.pathname)) {
 	// Table of Contents
 	var tocList = $("#toc ol");
 


### PR DESCRIPTION
If the URL ends with "/docs.html", the TOC will show up, but with just "/docs", it doesn't show up. This PR intends to fix this discrepancy.

Fixes #256