### PR TITLE
fix incompatibility to v1. $.ready(function() {}) used to work.

### DIFF
--- a/src/dom/set.js
+++ b/src/dom/set.js
@@ -8,6 +8,11 @@ function set (subject, property, value) {
 	if (property in setProps) {
 		setProps[property](subject, value);
 	}
+        else if (property === "dataset") {
+		for (const key of Object.keys(value)) {
+			subject.dataset[key]=value[key]
+		}
+        }
 	else if (property in subject) {
 		subject[property] = value;
 	}

--- a/src/events/delegate.js
+++ b/src/events/delegate.js
@@ -3,7 +3,7 @@ import bind from "./bind.js";
 
 function delegate (subject, type, selector, callback) {
 	bind(subject, type, function(evt) {
-		if (evt.target.closest(selector)) {
+		if ((evt.target.closest ? evt.target : evt.target.parentNode).closest(selector)) {
 			callback.call(subject, evt);
 		}
 	});

--- a/src/ready.js
+++ b/src/ready.js
@@ -1,7 +1,8 @@
-export default function ready (doc = document, callback, _isVoid) {
+export default function ready (doc, callback, _isVoid) {
 	if (typeof doc === "function" && !callback) {
 		[callback, doc] = [doc];
 	}
+	doc = doc || document;
 
 	if (callback) {
 		if (doc.readyState !== "loading") {


### PR DESCRIPTION
Bliss.ready(function() { dosomething;}) worked with v1 and should work with v2, too.

Dataset support for v2.

